### PR TITLE
refactor: modularize eBay browse parsers

### DIFF
--- a/app/tests/test_ebay_browse_parsers.py
+++ b/app/tests/test_ebay_browse_parsers.py
@@ -1,0 +1,149 @@
+import json
+from datetime import datetime, timezone
+
+from ebay_client.browse.parsers import parse_item_summary_response
+
+
+def test_parse_fixed_price_item_summary_response() -> None:
+    response = {
+        "itemSummaries": [
+            {
+                "itemId": "v1|123|0",
+                "legacyItemId": "123",
+                "title": "Pokemon Booster Box",
+                "price": {"value": "149.99", "currency": "GBP"},
+                "buyingOptions": ["FIXED_PRICE"],
+                "itemWebUrl": "https://www.ebay.co.uk/itm/123",
+                "image": {"imageUrl": "https://i.ebayimg.com/main.jpg"},
+                "seller": {"username": "cardseller", "feedbackPercentage": "99.8"},
+                "condition": "New",
+                "itemLocation": {"country": "GB", "postalCode": "SW1A"},
+                "itemCreationDate": "2026-04-01T10:30:00.000Z",
+                "itemEndDate": "2026-04-30T10:30:00.000Z",
+                "listingMarketplaceId": "EBAY_GB",
+            }
+        ]
+    }
+
+    item = parse_item_summary_response(response)[0]
+
+    assert item["ebay_id"] == "v1|123|0"
+    assert item["legacy_id"] == "123"
+    assert item["title"] == "Pokemon Booster Box"
+    assert item["price"] == 149.99
+    assert item["currency"] == "GBP"
+    assert item["current_bid"] == 0.0
+    assert item["current_bid_currency"] == "GBP"
+    assert item["url"] == "https://www.ebay.co.uk/itm/123"
+    assert item["image_url"] == "https://i.ebayimg.com/main.jpg"
+    assert item["seller"] == "cardseller"
+    assert item["seller_rating"] == "99.8"
+    assert item["condition"] == "New"
+    assert item["location"] == {"country": "GB", "postal_code": "SW1A"}
+    assert item["start_time"] == datetime(2026, 4, 1, 10, 30, tzinfo=timezone.utc)
+    assert item["end_time"] == datetime(2026, 4, 30, 10, 30, tzinfo=timezone.utc)
+    assert json.loads(item["buying_options"]) == ["FIXED_PRICE"]
+    assert item["auction_details"] is None
+    assert item["marketplace"] == "EBAY_GB"
+
+
+def test_parse_auction_item_summary_response() -> None:
+    response = {
+        "itemSummaries": [
+            {
+                "itemId": "v1|456|0",
+                "title": "Auction Card",
+                "price": {"value": "10.00", "currency": "GBP"},
+                "currentBidPrice": {"value": "22.50", "currency": "GBP"},
+                "bidCount": 7,
+                "buyingOptions": ["AUCTION"],
+                "itemEndDate": "2026-05-01T20:00:00.000Z",
+                "listingMarketplaceId": "EBAY_GB",
+            }
+        ]
+    }
+
+    item = parse_item_summary_response(response)[0]
+    auction_details = json.loads(item["auction_details"])
+
+    assert item["current_bid"] == 22.5
+    assert item["current_bid_currency"] == "GBP"
+    assert auction_details == {
+        "bid_count": 7,
+        "current_bid": {"value": 22.5, "currency": "GBP"},
+        "end_time": "2026-05-01T20:00:00.000Z",
+        "marketplace_id": "EBAY_GB",
+    }
+
+
+def test_parse_item_summary_response_handles_missing_optional_fields() -> None:
+    response = {"itemSummaries": [{"itemId": "v1|789|0"}]}
+
+    item = parse_item_summary_response(response)[0]
+
+    assert item["title"] == "No Title"
+    assert item["price"] == 0.0
+    assert item["currency"] == "GBP"
+    assert item["current_bid"] == 0.0
+    assert item["current_bid_currency"] == "GBP"
+    assert item["image_url"] is None
+    assert item["seller"] is None
+    assert item["seller_rating"] is None
+    assert item["location"] == {"country": None, "postal_code": None}
+    assert item["start_time"] is None
+    assert item["end_time"] is None
+    assert json.loads(item["buying_options"]) == []
+    assert item["auction_details"] is None
+    assert json.loads(item["categories"]) == {"ids": [], "names": []}
+    assert json.loads(item["images"]) == {"main": None, "thumbnails": []}
+
+
+def test_parse_item_summary_response_serializes_categories_and_images() -> None:
+    response = {
+        "itemSummaries": [
+            {
+                "categories": [
+                    {"categoryId": "183454", "categoryName": "CCG Sealed Boxes"},
+                    {"categoryId": "261328", "categoryName": "Pokemon Boxes"},
+                ],
+                "image": {"imageUrl": "https://i.ebayimg.com/main.jpg"},
+                "thumbnailImages": [
+                    {"imageUrl": "https://i.ebayimg.com/thumb-1.jpg"},
+                    {"imageUrl": "https://i.ebayimg.com/thumb-2.jpg"},
+                ],
+            }
+        ]
+    }
+
+    item = parse_item_summary_response(response)[0]
+
+    assert json.loads(item["categories"]) == {
+        "ids": ["183454", "261328"],
+        "names": ["CCG Sealed Boxes", "Pokemon Boxes"],
+    }
+    assert json.loads(item["images"]) == {
+        "main": "https://i.ebayimg.com/main.jpg",
+        "thumbnails": [
+            "https://i.ebayimg.com/thumb-1.jpg",
+            "https://i.ebayimg.com/thumb-2.jpg",
+        ],
+    }
+
+
+def test_parse_item_summary_response_uses_default_currency() -> None:
+    response = {
+        "itemSummaries": [
+            {
+                "price": {"value": "19.99"},
+                "currentBidPrice": {"value": "24.50"},
+                "buyingOptions": ["AUCTION"],
+            }
+        ]
+    }
+
+    item = parse_item_summary_response(response, default_currency="EUR")[0]
+    auction_details = json.loads(item["auction_details"])
+
+    assert item["currency"] == "EUR"
+    assert item["current_bid_currency"] == "EUR"
+    assert auction_details["current_bid"]["currency"] == "EUR"

--- a/ebay_client/__init__.py
+++ b/ebay_client/__init__.py
@@ -1,0 +1,1 @@
+"""Client-side helpers for external eBay APIs."""

--- a/ebay_client/browse/__init__.py
+++ b/ebay_client/browse/__init__.py
@@ -1,0 +1,5 @@
+"""Browse API response parsing helpers."""
+
+from ebay_client.browse.parsers import parse_item_summary_response
+
+__all__ = ["parse_item_summary_response"]

--- a/ebay_client/browse/auction.py
+++ b/ebay_client/browse/auction.py
@@ -1,0 +1,66 @@
+"""Auction parsing helpers for eBay Browse responses."""
+
+import json
+from typing import Any, Mapping, Sequence
+
+from ebay_client.browse.money import Money, parse_money
+
+
+def is_auction_item(buying_options: Sequence[str]) -> bool:
+    """Return whether an item summary is listed as an auction."""
+    return "AUCTION" in buying_options
+
+
+def build_auction_details(
+    item_data: Mapping[str, Any],
+    buying_options: Sequence[str],
+    default_currency: str,
+) -> dict[str, Any] | None:
+    """Build serialized auction payload data for auction item summaries."""
+    if not is_auction_item(buying_options):
+        return None
+
+    current_bid = parse_money(item_data.get("currentBidPrice"), default_currency)
+
+    return {
+        "bid_count": item_data.get("bidCount", 0),
+        "current_bid": current_bid,
+        "end_time": item_data.get("itemEndDate"),
+        "marketplace_id": item_data.get("listingMarketplaceId"),
+    }
+
+
+def serialize_auction_details(auction_details: Mapping[str, Any] | None) -> str | None:
+    """Serialize auction details when an item summary has auction data."""
+    if not auction_details:
+        return None
+
+    return json.dumps(auction_details)
+
+
+def get_current_bid_value(auction_details: Mapping[str, Any] | None) -> float:
+    """Return the current bid value for mapped item dictionaries."""
+    current_bid = _get_current_bid(auction_details)
+    return float(current_bid.get("value", 0.0)) if current_bid else 0.0
+
+
+def get_current_bid_currency(
+    auction_details: Mapping[str, Any] | None,
+    base_price: Money,
+) -> str:
+    """Return the current bid currency, falling back to the base price currency."""
+    current_bid = _get_current_bid(auction_details)
+    if not current_bid:
+        return str(base_price.get("currency", "GBP"))
+
+    return str(current_bid.get("currency") or base_price.get("currency", "GBP"))
+
+
+def _get_current_bid(
+    auction_details: Mapping[str, Any] | None,
+) -> Mapping[str, Any] | None:
+    if not auction_details:
+        return None
+
+    current_bid = auction_details.get("current_bid")
+    return current_bid if isinstance(current_bid, Mapping) else None

--- a/ebay_client/browse/categories.py
+++ b/ebay_client/browse/categories.py
@@ -1,0 +1,16 @@
+"""Category serialization helpers for eBay Browse responses."""
+
+import json
+from typing import Any, Mapping, Sequence
+
+
+def serialize_categories(categories: Sequence[Mapping[str, Any]] | None) -> str:
+    """Serialize eBay category data in the shape expected by item callers."""
+    categories = categories or []
+
+    return json.dumps(
+        {
+            "ids": [category.get("categoryId") for category in categories],
+            "names": [category.get("categoryName") for category in categories],
+        }
+    )

--- a/ebay_client/browse/dates.py
+++ b/ebay_client/browse/dates.py
@@ -1,0 +1,19 @@
+"""Datetime parsing helpers for eBay Browse responses."""
+
+from datetime import datetime, timezone
+
+
+def parse_ebay_datetime(date_value: str | None) -> datetime | None:
+    """Parse eBay Browse datetime strings into timezone-aware datetimes."""
+    if not date_value:
+        return None
+
+    try:
+        return datetime.strptime(date_value, "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError:
+        try:
+            return datetime.fromisoformat(date_value.replace("Z", "+00:00"))
+        except ValueError:
+            return None

--- a/ebay_client/browse/images.py
+++ b/ebay_client/browse/images.py
@@ -1,0 +1,31 @@
+"""Image serialization helpers for eBay Browse responses."""
+
+import json
+from typing import Any, Mapping, Sequence
+
+
+def get_main_image_url(item_data: Mapping[str, Any]) -> str | None:
+    """Return the primary image URL for an item summary."""
+    image = item_data.get("image") or {}
+
+    if not isinstance(image, Mapping):
+        return None
+
+    image_url = image.get("imageUrl")
+    return str(image_url) if image_url else None
+
+
+def serialize_images(item_data: Mapping[str, Any]) -> str:
+    """Serialize primary and thumbnail image URLs for storage."""
+    thumbnail_images = item_data.get("thumbnailImages") or []
+
+    return json.dumps(
+        {
+            "main": get_main_image_url(item_data),
+            "thumbnails": [
+                image.get("imageUrl")
+                for image in thumbnail_images
+                if isinstance(image, Mapping)
+            ],
+        }
+    )

--- a/ebay_client/browse/item_mapping.py
+++ b/ebay_client/browse/item_mapping.py
@@ -1,0 +1,76 @@
+"""Item summary mapping for eBay Browse responses."""
+
+import json
+from typing import Any, Mapping
+
+from ebay_client.browse.auction import (
+    build_auction_details,
+    get_current_bid_currency,
+    get_current_bid_value,
+    serialize_auction_details,
+)
+from ebay_client.browse.categories import serialize_categories
+from ebay_client.browse.dates import parse_ebay_datetime
+from ebay_client.browse.images import get_main_image_url, serialize_images
+from ebay_client.browse.money import parse_money
+
+
+def map_item_summary(
+    item_data: Mapping[str, Any],
+    default_currency: str,
+) -> dict[str, Any]:
+    """Map one eBay Browse item summary into the application's item shape."""
+    base_price = parse_money(item_data.get("price"), default_currency)
+    buying_options = _get_buying_options(item_data)
+    auction_details = build_auction_details(
+        item_data,
+        buying_options,
+        str(base_price["currency"]),
+    )
+
+    return {
+        "ebay_id": item_data.get("itemId"),
+        "legacy_id": item_data.get("legacyItemId"),
+        "title": item_data.get("title", "No Title"),
+        "price": base_price["value"],
+        "current_bid": get_current_bid_value(auction_details),
+        "current_bid_currency": get_current_bid_currency(auction_details, base_price),
+        "currency": base_price["currency"],
+        "url": item_data.get("itemWebUrl"),
+        "image_url": get_main_image_url(item_data),
+        "seller": _get_seller_value(item_data, "username"),
+        "seller_rating": _get_seller_value(item_data, "feedbackPercentage"),
+        "condition": item_data.get("condition"),
+        "location": _get_location(item_data),
+        "start_time": parse_ebay_datetime(item_data.get("itemCreationDate")),
+        "end_time": parse_ebay_datetime(item_data.get("itemEndDate")),
+        "buying_options": json.dumps(buying_options),
+        "auction_details": serialize_auction_details(auction_details),
+        "categories": serialize_categories(item_data.get("categories")),
+        "marketplace": item_data.get("listingMarketplaceId"),
+        "images": serialize_images(item_data),
+    }
+
+
+def _get_buying_options(item_data: Mapping[str, Any]) -> list[str]:
+    buying_options = item_data.get("buyingOptions") or []
+    return [str(option) for option in buying_options]
+
+
+def _get_seller_value(item_data: Mapping[str, Any], field_name: str) -> Any:
+    seller = item_data.get("seller") or {}
+    if not isinstance(seller, Mapping):
+        return None
+
+    return seller.get(field_name)
+
+
+def _get_location(item_data: Mapping[str, Any]) -> dict[str, Any]:
+    location = item_data.get("itemLocation") or {}
+    if not isinstance(location, Mapping):
+        location = {}
+
+    return {
+        "country": location.get("country"),
+        "postal_code": location.get("postalCode"),
+    }

--- a/ebay_client/browse/money.py
+++ b/ebay_client/browse/money.py
@@ -1,0 +1,29 @@
+"""Money parsing helpers for eBay Browse responses."""
+
+from typing import Any, Mapping
+
+Money = dict[str, float | str]
+
+
+def parse_money(
+    money_data: Mapping[str, Any] | None,
+    default_currency: str,
+) -> Money:
+    """Return a normalized money dictionary with a float value and currency."""
+    money_data = money_data or {}
+
+    return {
+        "value": _parse_float(money_data.get("value")),
+        "currency": str(money_data.get("currency") or default_currency),
+    }
+
+
+def _parse_float(value: Any) -> float:
+    """Convert an eBay numeric value to a float, defaulting blank values to 0."""
+    if value in (None, ""):
+        return 0.0
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0

--- a/ebay_client/browse/parsers.py
+++ b/ebay_client/browse/parsers.py
@@ -1,0 +1,21 @@
+"""Public parsers for eBay Browse API responses."""
+
+from typing import Any, Mapping
+
+from ebay_client.browse.item_mapping import map_item_summary
+
+
+def parse_item_summary_response(
+    response: Mapping[str, Any] | None,
+    default_currency: str = "GBP",
+) -> list[dict[str, Any]]:
+    """Parse an eBay Browse item summary search response."""
+    if not response:
+        return []
+
+    item_summaries = response.get("itemSummaries") or []
+    return [
+        map_item_summary(item_summary, default_currency)
+        for item_summary in item_summaries
+        if isinstance(item_summary, Mapping)
+    ]


### PR DESCRIPTION
## Summary
- add `ebay_client.browse.parse_item_summary_response` as the public Browse item summary parser entry point
- split parsing into focused helpers for money, auctions, categories, images, datetimes, and final item mapping
- add targeted parser tests for fixed-price items, auctions, missing optional fields, categories/images, and default currency fallback

## Validation
- `venv/bin/python -m pytest app/tests/test_ebay_browse_parsers.py`
- `venv/bin/python -m black .` was run; unrelated pre-existing formatting churn was reverted to keep the PR scoped
- `venv/bin/python -m black --check ebay_client app/tests/test_ebay_browse_parsers.py`
- `venv/bin/python -m mypy .` fails on existing repo-wide typing/stub issues outside this change, including missing stubs and stale test imports
- `venv/bin/python -m mypy ebay_client`
- `ENCRYPTION_KEY=... venv/bin/python -m pytest -x` fails during collection on existing `app/tests/end_to_end/test_scheduler.py` importing missing `app.models.Query`

No GitHub issue number was provided for this AO task, and no matching issue was found by search.