### PR TITLE
[codex] Refactor eBay analytics utilities

### DIFF
--- a/app/tests/test_ebay_analytics.py
+++ b/app/tests/test_ebay_analytics.py
@@ -1,0 +1,132 @@
+from typing import Any
+
+import pytest
+
+from ebay_client.analytics.client import EbayAnalyticsClient
+from ebay_client.analytics.rate_limits import extract_browse_rate
+
+
+class FakeResponse:
+    """Small response double for analytics client tests."""
+
+    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self.payload = payload
+        self.raise_called = False
+
+    def json(self) -> dict[str, Any]:
+        """Return the configured JSON payload."""
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        """Track that status handling was delegated to the response."""
+        self.raise_called = True
+
+
+class FakeSession:
+    """Small session double that records the outgoing analytics request."""
+
+    def __init__(self, response: FakeResponse) -> None:
+        self.response = response
+        self.last_url: str | None = None
+        self.last_headers: dict[str, str] | None = None
+
+    def get(self, url: str, headers: dict[str, str]) -> FakeResponse:
+        """Return the configured response and capture request details."""
+        self.last_url = url
+        self.last_headers = headers
+        return self.response
+
+
+RATE_LIMIT_PAYLOAD = {
+    "rateLimits": [
+        {
+            "apiContext": "sell",
+            "apiName": "Inventory",
+            "resources": [],
+        },
+        {
+            "apiContext": "buy",
+            "apiName": "Browse",
+            "resources": [
+                {"name": "buy.other", "rates": [{"limit": 1}]},
+                {
+                    "name": "buy.browse",
+                    "rates": [
+                        {
+                            "limit": 5000,
+                            "remaining": 4999,
+                            "reset": "2026-04-29T00:00:00.000Z",
+                        }
+                    ],
+                },
+            ],
+        },
+    ]
+}
+
+
+def test_get_rate_limits_raises_for_missing_scope() -> None:
+    response = FakeResponse(status_code=403, payload={})
+    client = EbayAnalyticsClient(access_token="token", session=FakeSession(response))
+
+    with pytest.raises(ValueError, match="Missing required scope"):
+        client.get_rate_limits()
+
+    assert response.raise_called is False
+
+
+def test_get_browse_limits_extracts_first_browse_rate() -> None:
+    response = FakeResponse(status_code=200, payload=RATE_LIMIT_PAYLOAD)
+    session = FakeSession(response)
+    client = EbayAnalyticsClient(access_token="token", session=session)
+
+    assert client.get_browse_limits() == {
+        "limit": 5000,
+        "remaining": 4999,
+        "reset": "2026-04-29T00:00:00.000Z",
+    }
+    assert session.last_url == (
+        "https://api.ebay.com/developer/analytics/v1_beta/rate_limit"
+    )
+    assert session.last_headers == {"Authorization": "Bearer token"}
+    assert response.raise_called is True
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"rateLimits": []},
+        {"rateLimits": [{"apiContext": "sell", "apiName": "Browse"}]},
+        {
+            "rateLimits": [
+                {
+                    "apiContext": "buy",
+                    "apiName": "Browse",
+                    "resources": [{"name": "buy.other", "rates": [{"limit": 1}]}],
+                }
+            ]
+        },
+        {
+            "rateLimits": [
+                {
+                    "apiContext": "buy",
+                    "apiName": "Browse",
+                    "resources": [{"name": "buy.browse", "rates": []}],
+                }
+            ]
+        },
+    ],
+)
+def test_extract_browse_rate_returns_empty_dict_for_missing_paths(
+    payload: dict[str, Any],
+) -> None:
+    assert extract_browse_rate(payload) == {}
+
+
+def test_get_search_limits_uses_browse_rate_limits() -> None:
+    response = FakeResponse(status_code=200, payload=RATE_LIMIT_PAYLOAD)
+    client = EbayAnalyticsClient(access_token="token", session=FakeSession(response))
+
+    assert client.get_search_limits()["limit"] == 5000

--- a/app/tests/test_ebay_utilities.py
+++ b/app/tests/test_ebay_utilities.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from ebay_client.browse.responses import dedupe_items
+from ebay_client.time import parse_ebay_datetime
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (
+            "2026-04-28T13:45:10.000Z",
+            datetime(2026, 4, 28, 13, 45, 10, tzinfo=timezone.utc),
+        ),
+        (
+            "2026-04-28T13:45:10Z",
+            datetime(2026, 4, 28, 13, 45, 10, tzinfo=timezone.utc),
+        ),
+        (
+            "2026-04-28T14:45:10+01:00",
+            datetime.fromisoformat("2026-04-28T14:45:10+01:00"),
+        ),
+    ],
+)
+def test_parse_ebay_datetime_supported_formats(
+    value: str,
+    expected: datetime,
+) -> None:
+    assert parse_ebay_datetime(value) == expected
+
+
+@pytest.mark.parametrize("value", [None, "", "not-a-date", "2026-99-99T00:00:00Z"])
+def test_parse_ebay_datetime_invalid_or_missing_values(
+    value: str | None,
+) -> None:
+    assert parse_ebay_datetime(value) is None
+
+
+def test_dedupe_items_preserves_first_id_match_and_items_without_ids() -> None:
+    first = {"ebay_id": "1", "title": "first"}
+    duplicate = {"ebay_id": "1", "title": "duplicate"}
+    no_id = {"title": "no id"}
+    empty_id = {"ebay_id": "", "title": "empty id"}
+    second = {"ebay_id": "2", "title": "second"}
+
+    assert dedupe_items([first, duplicate, no_id, empty_id, second]) == [
+        first,
+        no_id,
+        empty_id,
+        second,
+    ]
+
+
+def test_dedupe_items_accepts_any_iterable() -> None:
+    items = (
+        {"ebay_id": str(item_id), "title": f"item {item_id}"} for item_id in [1, 1, 2]
+    )
+
+    assert [item["ebay_id"] for item in dedupe_items(items)] == ["1", "2"]

--- a/ebay_client/__init__.py
+++ b/ebay_client/__init__.py
@@ -1,0 +1,1 @@
+"""Small eBay API client helpers."""

--- a/ebay_client/analytics/__init__.py
+++ b/ebay_client/analytics/__init__.py
@@ -1,0 +1,6 @@
+"""eBay analytics client helpers."""
+
+from ebay_client.analytics.client import EbayAnalyticsClient
+from ebay_client.analytics.rate_limits import extract_browse_rate
+
+__all__ = ["EbayAnalyticsClient", "extract_browse_rate"]

--- a/ebay_client/analytics/client.py
+++ b/ebay_client/analytics/client.py
@@ -1,0 +1,77 @@
+"""Client for eBay Developer Analytics endpoints."""
+
+from typing import Any, Protocol
+
+import requests  # type: ignore[import-untyped]
+
+from ebay_client.analytics.rate_limits import extract_browse_rate
+
+
+class _AnalyticsResponse(Protocol):
+    """Protocol for response objects returned by requests-like sessions."""
+
+    status_code: int
+
+    def json(self) -> dict[str, Any]:
+        """Return decoded response JSON."""
+        ...
+
+    def raise_for_status(self) -> None:
+        """Raise for non-successful HTTP statuses."""
+        ...
+
+
+class _AnalyticsSession(Protocol):
+    """Protocol for session objects used by the analytics client."""
+
+    def get(self, url: str, headers: dict[str, str]) -> _AnalyticsResponse:
+        """Send a GET request."""
+        ...
+
+
+class EbayAnalyticsClient:
+    """Fetch eBay developer analytics rate-limit data."""
+
+    DEFAULT_BASE_URL = "https://api.ebay.com/developer/analytics/v1_beta"
+
+    def __init__(
+        self,
+        access_token: str | None = None,
+        *,
+        token: str | None = None,
+        session: _AnalyticsSession | None = None,
+        base_url: str = DEFAULT_BASE_URL,
+    ) -> None:
+        """Create an analytics client.
+
+        ``token`` is accepted as a compatibility alias for ``access_token``.
+        """
+        self.access_token = access_token or token
+        self.session = session or requests.Session()
+        self.base_url = base_url.rstrip("/")
+
+    def get_rate_limits(self) -> dict[str, Any]:
+        """Fetch raw eBay API rate-limit data."""
+        response = self.session.get(
+            f"{self.base_url}/rate_limit",
+            headers=self._headers(),
+        )
+        if response.status_code == 403:
+            raise ValueError("Missing required scope")
+
+        response.raise_for_status()
+        return response.json()
+
+    def get_browse_limits(self) -> dict[str, Any]:
+        """Return the first Browse API rate-limit record."""
+        return extract_browse_rate(self.get_rate_limits())
+
+    def get_search_limits(self) -> dict[str, Any]:
+        """Return search-related limits, currently backed by Browse limits."""
+        return extract_browse_rate(self.get_rate_limits())
+
+    def _headers(self) -> dict[str, str]:
+        """Build request headers for the analytics API."""
+        if not self.access_token:
+            return {}
+        return {"Authorization": f"Bearer {self.access_token}"}

--- a/ebay_client/analytics/rate_limits.py
+++ b/ebay_client/analytics/rate_limits.py
@@ -1,0 +1,56 @@
+"""Helpers for extracting eBay analytics rate-limit data."""
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+RateLimitPayload = Mapping[str, Any]
+RateLimitRecord = dict[str, Any]
+
+
+def extract_browse_rate(rate_data: RateLimitPayload) -> RateLimitRecord:
+    """Return the first buy Browse API rate-limit record.
+
+    eBay nests Browse limits under:
+    rateLimits -> buy/Browse group -> buy.browse resource -> rates[0].
+    Return an empty dict when any part of that path is missing.
+    """
+    browse_group = _find_browse_group(rate_data)
+    if browse_group is None:
+        return {}
+
+    browse_resource = _find_browse_resource(browse_group)
+    if browse_resource is None:
+        return {}
+
+    return _first_rate(browse_resource)
+
+
+def _find_browse_group(rate_data: RateLimitPayload) -> Mapping[str, Any] | None:
+    """Find the top-level buy Browse API group."""
+    for group in _mapping_sequence(rate_data.get("rateLimits")):
+        if group.get("apiContext") == "buy" and group.get("apiName") == "Browse":
+            return group
+    return None
+
+
+def _find_browse_resource(group: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Find the nested buy.browse resource."""
+    for resource in _mapping_sequence(group.get("resources")):
+        if resource.get("name") == "buy.browse":
+            return resource
+    return None
+
+
+def _first_rate(resource: Mapping[str, Any]) -> RateLimitRecord:
+    """Return the first rate record from a resource."""
+    rates = _mapping_sequence(resource.get("rates"))
+    if not rates:
+        return {}
+    return dict(rates[0])
+
+
+def _mapping_sequence(value: Any) -> list[Mapping[str, Any]]:
+    """Return only mapping entries from a sequence-like value."""
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]

--- a/ebay_client/browse/__init__.py
+++ b/ebay_client/browse/__init__.py
@@ -1,0 +1,5 @@
+"""eBay Browse API helpers."""
+
+from ebay_client.browse.responses import dedupe_items
+
+__all__ = ["dedupe_items"]

--- a/ebay_client/browse/responses.py
+++ b/ebay_client/browse/responses.py
@@ -1,0 +1,33 @@
+"""Response helpers for eBay Browse API data."""
+
+from collections.abc import Iterable, Mapping, MutableMapping
+from typing import Any, TypeVar
+
+Item = TypeVar("Item", bound=MutableMapping[str, Any])
+
+
+def dedupe_items(items: Iterable[Item]) -> list[Item]:
+    """Remove duplicate items by ``ebay_id`` while preserving order.
+
+    Items without an ``ebay_id`` are always preserved.
+    """
+    seen_ids: set[Any] = set()
+    unique_items: list[Item] = []
+
+    for item in items:
+        if _should_keep_item(item, seen_ids):
+            unique_items.append(item)
+
+    return unique_items
+
+
+def _should_keep_item(item: Mapping[str, Any], seen_ids: set[Any]) -> bool:
+    """Return whether an item should be included in the de-duped output."""
+    ebay_id = item.get("ebay_id")
+    if not ebay_id:
+        return True
+    if ebay_id in seen_ids:
+        return False
+
+    seen_ids.add(ebay_id)
+    return True

--- a/ebay_client/time.py
+++ b/ebay_client/time.py
@@ -1,0 +1,39 @@
+"""Date and time utilities for eBay payloads."""
+
+from datetime import datetime, timezone
+
+EBAY_UTC_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def parse_ebay_datetime(value: str | None) -> datetime | None:
+    """Parse supported eBay datetime values.
+
+    Returns ``None`` for missing or invalid input.
+    """
+    if not value:
+        return None
+
+    return _parse_utc_datetime(value) or _parse_iso_datetime(value)
+
+
+def _parse_utc_datetime(value: str) -> datetime | None:
+    """Parse eBay's canonical UTC datetime format."""
+    try:
+        return datetime.strptime(value, EBAY_UTC_FORMAT).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _parse_iso_datetime(value: str) -> datetime | None:
+    """Parse ISO datetimes, including values with a trailing ``Z``."""
+    try:
+        return datetime.fromisoformat(_normalize_z_suffix(value))
+    except ValueError:
+        return None
+
+
+def _normalize_z_suffix(value: str) -> str:
+    """Convert an ISO trailing ``Z`` timezone marker to ``+00:00``."""
+    if value.endswith("Z"):
+        return f"{value[:-1]}+00:00"
+    return value


### PR DESCRIPTION
## Summary
- Add a small `ebay_client` package for analytics rate-limit extraction, analytics API access, eBay datetime parsing, and Browse response de-duplication.
- Decompose Browse rate-limit traversal into focused helpers that return `{}` when the expected group/resource/rate path is missing.
- Add offline tests for analytics 403 handling, successful and missing rate extraction, datetime parsing, invalid inputs, and de-duping items with and without `ebay_id`.

## Issue
No tracker issue number was provided for this AO task.

## Validation
- `pytest app/tests/test_ebay_analytics.py app/tests/test_ebay_utilities.py` passed: 17 passed.
- `black .` was run; it reformatted broad legacy files, so unrelated formatter churn was removed and scoped files were left formatted.
- `mypy ebay_client` passed.
- `pytest` currently fails during collection on existing repository issues/environment gaps: missing `Query` model exports, missing `pandas`/`stripe`, and missing `ENCRYPTION_KEY`.
- `mypy .` currently fails on existing missing stubs/dependencies and legacy type issues across the app.
