### PR TITLE
[codex] Modularize eBay browse filters

### DIFF
--- a/app/tests/test_ebay_browse_filters.py
+++ b/app/tests/test_ebay_browse_filters.py
@@ -1,0 +1,64 @@
+from ebay_client.browse.dto import SearchFilters
+from ebay_client.browse.filters import SearchFilterBuilder, build_search_filter
+
+
+def test_condition_filters_include_only_supported_conditions():
+    builder = SearchFilterBuilder("GBP")
+
+    assert "conditions" not in builder.build({"condition": ""})
+    assert builder.build({"condition": "NEW"}) == "conditions:{NEW}"
+    assert builder.build({"condition": "USED"}) == "conditions:{USED}"
+    assert "conditions" not in builder.build({"condition": "RENEWED"})
+
+
+def test_buying_options_filters_skip_any_and_include_specific_options():
+    builder = SearchFilterBuilder("GBP")
+
+    assert builder.build({"buying_options": "FIXED_PRICE|AUCTION"}) == ""
+    assert builder.build({"buying_options": "any"}) == ""
+    assert builder.build({"buying_options": "FIXED_PRICE"}) == (
+        "buyingOptions:{FIXED_PRICE}"
+    )
+    assert builder.build({"buying_options": "AUCTION"}) == "buyingOptions:{AUCTION}"
+
+
+def test_location_filter_skips_any_and_includes_specific_country():
+    builder = SearchFilterBuilder("GBP")
+
+    assert builder.build({"item_location": "any"}) == ""
+    assert builder.build({"item_location": "GB"}) == "itemLocationCountry:GB"
+
+
+def test_price_range_filters_include_currency_and_requested_bounds():
+    builder = SearchFilterBuilder("GBP")
+
+    assert builder.build({"min_price": 10}) == "priceCurrency:GBP,price:[10..]"
+    assert builder.build({"max_price": 50}) == "priceCurrency:GBP,price:[..50]"
+    assert builder.build({"min_price": 10, "max_price": 50}) == (
+        "priceCurrency:GBP,price:[10..50]"
+    )
+
+
+def test_dict_and_search_filters_input_build_identical_filter_strings():
+    filters_dict = {
+        "item_location": "US",
+        "buying_options": "AUCTION",
+        "condition": "USED",
+        "min_price": 25,
+        "max_price": 75,
+    }
+    search_filters = SearchFilters(
+        item_location="US",
+        buying_options="AUCTION",
+        condition="USED",
+        min_price=25,
+        max_price=75,
+    )
+
+    assert build_search_filter(filters_dict, "USD") == build_search_filter(
+        search_filters, "USD"
+    )
+    assert build_search_filter(search_filters, "USD") == (
+        "itemLocationCountry:US,buyingOptions:{AUCTION},"
+        "conditions:{USED},priceCurrency:USD,price:[25..75]"
+    )

--- a/ebay_client/__init__.py
+++ b/ebay_client/__init__.py
@@ -1,0 +1,1 @@
+"""eBay client package."""

--- a/ebay_client/browse/__init__.py
+++ b/ebay_client/browse/__init__.py
@@ -1,0 +1,6 @@
+"""Browse API helpers."""
+
+from .dto import SearchFilters
+from .filters import SearchFilterBuilder, build_search_filter
+
+__all__ = ["SearchFilterBuilder", "SearchFilters", "build_search_filter"]

--- a/ebay_client/browse/dto.py
+++ b/ebay_client/browse/dto.py
@@ -1,0 +1,59 @@
+"""Data transfer objects for eBay Browse API requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, TypeAlias
+
+PriceBound: TypeAlias = int | float | str
+SearchFilterInput: TypeAlias = "SearchFilters | Mapping[str, object] | None"
+
+
+@dataclass(frozen=True)
+class SearchFilters:
+    """Normalized eBay Browse search filter options."""
+
+    item_location: str | None = None
+    buying_options: str | None = None
+    condition: str | None = None
+    min_price: PriceBound | None = None
+    max_price: PriceBound | None = None
+
+    @classmethod
+    def from_mapping(cls, filters: Mapping[str, object] | None) -> "SearchFilters":
+        """Create search filters from a mapping, ignoring unknown keys."""
+        if filters is None:
+            return cls()
+
+        return cls(
+            item_location=_optional_string(filters.get("item_location")),
+            buying_options=_optional_string(filters.get("buying_options")),
+            condition=_optional_string(filters.get("condition")),
+            min_price=_optional_price_bound(filters.get("min_price")),
+            max_price=_optional_price_bound(filters.get("max_price")),
+        )
+
+
+def normalize_search_filters(filters: SearchFilterInput) -> SearchFilters:
+    """Return a SearchFilters instance for dataclass, mapping, or empty input."""
+    if isinstance(filters, SearchFilters):
+        return filters
+
+    return SearchFilters.from_mapping(filters)
+
+
+def _optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+
+    return str(value)
+
+
+def _optional_price_bound(value: object) -> PriceBound | None:
+    if value is None:
+        return None
+
+    if isinstance(value, (int, float, str)):
+        return value
+
+    return str(value)

--- a/ebay_client/browse/filters.py
+++ b/ebay_client/browse/filters.py
@@ -1,0 +1,84 @@
+"""Filter construction helpers for eBay Browse search requests."""
+
+from __future__ import annotations
+
+from .dto import SearchFilterInput, SearchFilters, normalize_search_filters
+
+ANY_BUYING_OPTIONS = frozenset({"", "any", "ANY", "FIXED_PRICE|AUCTION"})
+VALID_CONDITIONS = frozenset({"NEW", "USED"})
+
+
+class SearchFilterBuilder:
+    """Build eBay Browse API filter strings from search filter options."""
+
+    def __init__(self, currency: str) -> None:
+        self.currency = currency
+
+    def build(self, filters: SearchFilterInput) -> str:
+        """Build a comma-separated Browse API filter string."""
+        normalized_filters = normalize_search_filters(filters)
+        parts = [
+            _build_location_filter(normalized_filters),
+            _build_buying_options_filter(normalized_filters),
+            _build_condition_filter(normalized_filters),
+            _build_currency_filter(normalized_filters, self.currency),
+            _build_price_range_filter(normalized_filters),
+        ]
+
+        return ",".join(part for part in parts if part is not None)
+
+
+def build_search_filter(filters: SearchFilterInput, currency: str) -> str:
+    """Build an eBay Browse API filter string with the default builder."""
+    return SearchFilterBuilder(currency).build(filters)
+
+
+def _build_location_filter(filters: SearchFilters) -> str | None:
+    location = filters.item_location
+    if location and location != "any":
+        return f"itemLocationCountry:{location}"
+
+    return None
+
+
+def _build_buying_options_filter(filters: SearchFilters) -> str | None:
+    buying_options = filters.buying_options or "FIXED_PRICE|AUCTION"
+    if buying_options in ANY_BUYING_OPTIONS:
+        return None
+
+    return f"buyingOptions:{{{buying_options}}}"
+
+
+def _build_condition_filter(filters: SearchFilters) -> str | None:
+    condition = filters.condition
+    if condition in VALID_CONDITIONS:
+        return f"conditions:{{{condition}}}"
+
+    return None
+
+
+def _build_currency_filter(filters: SearchFilters, currency: str) -> str | None:
+    if _has_price_range(filters):
+        return f"priceCurrency:{currency}"
+
+    return None
+
+
+def _build_price_range_filter(filters: SearchFilters) -> str | None:
+    min_price = filters.min_price
+    max_price = filters.max_price
+
+    if min_price is not None and max_price is not None:
+        return f"price:[{min_price}..{max_price}]"
+
+    if min_price is not None:
+        return f"price:[{min_price}..]"
+
+    if max_price is not None:
+        return f"price:[..{max_price}]"
+
+    return None
+
+
+def _has_price_range(filters: SearchFilters) -> bool:
+    return filters.min_price is not None or filters.max_price is not None


### PR DESCRIPTION
## Summary
- Add a modular `ebay_client.browse` filter construction layer with `SearchFilterBuilder(currency).build(filters)` and `build_search_filter(filters, currency)` compatibility entry points.
- Normalize dict and `SearchFilters` inputs through a browse DTO.
- Add focused tests for condition, buying option, location, price range, and dict/dataclass filter inputs.

## Issue
No issue number was provided in the task context.

## Validation
- `pytest app/tests/test_ebay_browse_filters.py` passed.
- `black .` ran; unrelated formatter churn was removed to keep the PR scoped.
- `black --check ebay_client app/tests/test_ebay_browse_filters.py` passed.
- `mypy ebay_client` passed.
- `pytest` currently fails during collection on existing unrelated issues: missing `Query`, `archive_items`, `load_historical_items`, `cancel_subscription_logic`, and missing `ENCRYPTION_KEY`.
- `mypy .` currently fails on existing unrelated project-wide typing issues and missing third-party stubs.