### PR TITLE
[codex] Refactor eBay auth config token flow

### DIFF
--- a/app/tests/test_ebay_auth_config.py
+++ b/app/tests/test_ebay_auth_config.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from ebay_client.auth.datetime_utils import parse_datetime
+from ebay_client.auth.provider import EbayTokenProvider
+from ebay_client.auth.token_store import EbayTokenStore, load_tokens, save_tokens
+from ebay_client.config.credentials import load_ebay_credentials
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class FakeSession:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+        self.calls: list[dict[str, Any]] = []
+
+    def post(self, *args: Any, **kwargs: Any) -> FakeResponse:
+        self.calls.append({"args": args, "kwargs": kwargs})
+        return FakeResponse(self.payload)
+
+
+def test_load_ebay_credentials_from_json_env() -> None:
+    expires_at = "2026-04-28T12:00:00Z"
+    environ = {
+        "EBAY_CREDENTIALS_JSON": json.dumps(
+            [
+                {
+                    "client_id": "client-json",
+                    "client_secret": "secret-json",
+                    "token": "cached",
+                    "token_expiry": expires_at,
+                }
+            ]
+        )
+    }
+
+    credentials = load_ebay_credentials(environ)
+
+    assert credentials == [
+        {
+            "client_id": "client-json",
+            "client_secret": "secret-json",
+            "token": "cached",
+            "token_expiry": datetime(2026, 4, 28, 12, 0, tzinfo=timezone.utc),
+        }
+    ]
+
+
+def test_load_ebay_credentials_from_single_env_fallback() -> None:
+    credentials = load_ebay_credentials(
+        {
+            "EBAY_CLIENT_ID": "client-env",
+            "EBAY_CLIENT_SECRET": "secret-env",
+        }
+    )
+
+    assert credentials == [
+        {
+            "client_id": "client-env",
+            "client_secret": "secret-env",
+            "token": None,
+            "token_expiry": None,
+        }
+    ]
+
+
+def test_load_ebay_credentials_empty_env_returns_empty_list() -> None:
+    assert load_ebay_credentials({}) == []
+
+
+def test_get_token_refreshes_expired_credential_and_syncs_index() -> None:
+    session = FakeSession({"access_token": "fresh-token", "expires_in": 3600})
+    credentials = [
+        {
+            "client_id": "client-refresh",
+            "client_secret": "secret-refresh",
+            "token": None,
+            "token_expiry": None,
+        }
+    ]
+    provider = EbayTokenProvider(credentials=credentials, session=session)
+
+    token = provider.get_token()
+
+    assert token == "fresh-token"
+    assert provider.current_cred_index == 0
+    assert provider.credentials[0]["token"] == "fresh-token"
+    assert credentials[0]["token"] == "fresh-token"
+    assert provider.credentials[0]["token_expiry"] > datetime.now(timezone.utc)
+    assert session.calls[0]["kwargs"]["auth"] == ("client-refresh", "secret-refresh")
+    assert session.calls[0]["kwargs"]["data"] == {
+        "grant_type": "client_credentials",
+        "scope": "https://api.ebay.com/oauth/api_scope",
+    }
+
+
+def test_get_token_returns_cached_token_without_refresh() -> None:
+    session = FakeSession({"access_token": "unused-token", "expires_in": 3600})
+    provider = EbayTokenProvider(
+        credentials=[
+            {
+                "client_id": "client-cached",
+                "client_secret": "secret-cached",
+                "token": "cached-token",
+                "token_expiry": datetime.now(timezone.utc) + timedelta(hours=1),
+            }
+        ],
+        session=session,
+    )
+
+    assert provider.get_token() == "cached-token"
+    assert session.calls == []
+
+
+def test_token_store_save_and_load_round_trip(tmp_path: Any) -> None:
+    path = tmp_path / "tokens.json"
+    expiry = datetime(2026, 4, 28, 13, 30, tzinfo=timezone.utc)
+
+    save_tokens(
+        path,
+        {
+            "client-store": {
+                "token": "stored-token",
+                "token_expiry": expiry,
+            }
+        },
+    )
+
+    assert load_tokens(path) == {
+        "client-store": {
+            "token": "stored-token",
+            "token_expiry": expiry,
+        }
+    }
+
+
+def test_provider_loads_and_saves_through_token_store(tmp_path: Any) -> None:
+    path = tmp_path / "tokens.json"
+    store = EbayTokenStore(path)
+    store.save(
+        {
+            "client-store": {
+                "token": "stored-token",
+                "token_expiry": datetime.now(timezone.utc) + timedelta(hours=1),
+            }
+        }
+    )
+    provider = EbayTokenProvider(
+        credentials=[
+            {
+                "client_id": "client-store",
+                "client_secret": "secret-store",
+                "token": None,
+                "token_expiry": None,
+            }
+        ],
+        token_store=store,
+    )
+
+    assert provider.get_token() == "stored-token"
+
+
+def test_parse_datetime_accepts_z_suffix_and_naive_values() -> None:
+    assert parse_datetime("2026-04-28T12:00:00Z") == datetime(
+        2026,
+        4,
+        28,
+        12,
+        0,
+        tzinfo=timezone.utc,
+    )
+    assert parse_datetime("2026-04-28T12:00:00") == datetime(
+        2026,
+        4,
+        28,
+        12,
+        0,
+        tzinfo=timezone.utc,
+    )

--- a/ebay_client/__init__.py
+++ b/ebay_client/__init__.py
@@ -1,0 +1,1 @@
+"""eBay client support package."""

--- a/ebay_client/auth/__init__.py
+++ b/ebay_client/auth/__init__.py
@@ -1,0 +1,6 @@
+"""Authentication helpers for eBay API clients."""
+
+from ebay_client.auth.provider import EbayTokenProvider
+from ebay_client.auth.token_store import EbayTokenStore
+
+__all__ = ["EbayTokenProvider", "EbayTokenStore"]

--- a/ebay_client/auth/datetime_utils.py
+++ b/ebay_client/auth/datetime_utils.py
@@ -1,0 +1,36 @@
+"""Datetime parsing and serialization helpers for token metadata."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def parse_datetime(value: object) -> datetime | None:
+    """Return an aware UTC datetime from common token-store values."""
+    if value is None or value == "":
+        return None
+
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        normalized = value
+        if normalized.endswith("Z"):
+            normalized = f"{normalized[:-1]}+00:00"
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError as exc:
+            raise ValueError(f"Invalid datetime value: {value!r}") from exc
+    else:
+        raise TypeError(f"Unsupported datetime value: {value!r}")
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def serialize_datetime(value: object) -> str | None:
+    """Return an ISO-8601 string for a datetime-like value."""
+    parsed = parse_datetime(value)
+    if parsed is None:
+        return None
+    return parsed.isoformat()

--- a/ebay_client/auth/provider.py
+++ b/ebay_client/auth/provider.py
@@ -1,0 +1,159 @@
+"""OAuth token provider for eBay client-credentials auth."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+import requests  # type: ignore[import-untyped]
+
+from ebay_client.auth.rotation import CredentialRotator
+from ebay_client.auth.token_store import EbayTokenStore
+from ebay_client.config.credentials import load_ebay_credentials, normalize_credentials
+
+TOKEN_URL = "https://api.ebay.com/identity/v1/oauth2/token"
+DEFAULT_SCOPE = "https://api.ebay.com/oauth/api_scope"
+FORM_HEADERS = {"Content-Type": "application/x-www-form-urlencoded"}
+
+Credential = dict[str, Any]
+
+
+class TokenStore(Protocol):
+    """Protocol for token stores used by the provider."""
+
+    def apply_to_credentials(self, credentials: list[Credential]) -> None:
+        """Apply persisted token fields to credentials."""
+
+    def update_credential(self, credential: Credential) -> None:
+        """Persist token fields from a credential."""
+
+
+class EbayTokenProvider:
+    """Provide cached or freshly refreshed eBay OAuth access tokens."""
+
+    def __init__(
+        self,
+        credentials: Iterable[Mapping[str, Any]] | Mapping[str, Any] | None = None,
+        token_store: TokenStore | str | Path | None = None,
+        session: requests.Session | None = None,
+        token_url: str = TOKEN_URL,
+        scope: str | Iterable[str] = DEFAULT_SCOPE,
+        refresh_margin: timedelta = timedelta(seconds=60),
+        environ: Mapping[str, str] | None = None,
+        request_timeout: float = 30.0,
+        start_index: int = 0,
+    ) -> None:
+        """Create a token provider while preserving constructor flexibility."""
+        raw_credentials = (
+            credentials if credentials is not None else load_ebay_credentials(environ)
+        )
+        self.credentials = normalize_credentials(raw_credentials)
+        self.token_store = _build_token_store(token_store)
+        self.session = session or requests.Session()
+        self.token_url = token_url
+        self.scope = _normalize_scope(scope)
+        self.refresh_margin = refresh_margin
+        self.request_timeout = request_timeout
+        self._rotator = CredentialRotator(self.credentials, start_index)
+        self._load_stored_tokens()
+
+    @property
+    def current_cred_index(self) -> int:
+        """Return the index that will be used for the next credential."""
+        return self._rotator.index
+
+    @current_cred_index.setter
+    def current_cred_index(self, value: int) -> None:
+        self._rotator.index = value
+
+    def get_token(self) -> str:
+        """Return an access token, refreshing the selected credential if needed."""
+        credential = self._get_current_credential()
+        if self._token_needs_refresh(credential):
+            self._refresh_credential(credential)
+        return str(credential["token"])
+
+    def _get_token(self) -> str:
+        """Backward-compatible alias for older internal callers."""
+        return self.get_token()
+
+    def _get_current_credential(self) -> Credential:
+        """Return the next round-robin credential."""
+        return self._rotator.next()
+
+    def _token_needs_refresh(self, credential: Mapping[str, Any]) -> bool:
+        """Return whether the credential lacks a reusable access token."""
+        token = credential.get("token")
+        token_expiry = credential.get("token_expiry")
+
+        if not token or not token_expiry:
+            return True
+
+        return _utc_now() > token_expiry - self.refresh_margin
+
+    def _refresh_credential(self, credential: Credential) -> None:
+        """Refresh one credential and persist its token fields."""
+        token_data = self._request_token(credential)
+        credential["token"] = token_data["access_token"]
+        credential["token_expiry"] = _utc_now() + timedelta(
+            seconds=int(token_data["expires_in"])
+        )
+        self._save_credential(credential)
+
+    def _request_token(self, credential: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Request a fresh OAuth token for one eBay credential."""
+        response = self.session.post(
+            self.token_url,
+            auth=(credential["client_id"], credential["client_secret"]),
+            headers=FORM_HEADERS,
+            data={
+                "grant_type": "client_credentials",
+                "scope": self.scope,
+            },
+            timeout=self.request_timeout,
+        )
+        response.raise_for_status()
+        token_data = response.json()
+        _validate_token_response(token_data)
+        return token_data
+
+    def _load_stored_tokens(self) -> None:
+        if self.token_store is not None:
+            self.token_store.apply_to_credentials(self.credentials)
+
+    def _save_credential(self, credential: Credential) -> None:
+        if self.token_store is not None:
+            self.token_store.update_credential(credential)
+
+
+def _build_token_store(
+    token_store: TokenStore | str | Path | None,
+) -> TokenStore | None:
+    if token_store is None:
+        return None
+    if _has_token_store_methods(token_store):
+        return cast(TokenStore, token_store)
+    return EbayTokenStore(cast(str | Path, token_store))
+
+
+def _has_token_store_methods(candidate: object) -> bool:
+    return hasattr(candidate, "apply_to_credentials") and hasattr(
+        candidate, "update_credential"
+    )
+
+
+def _normalize_scope(scope: str | Iterable[str]) -> str:
+    if isinstance(scope, str):
+        return scope
+    return " ".join(scope)
+
+
+def _validate_token_response(token_data: Mapping[str, Any]) -> None:
+    if "access_token" not in token_data or "expires_in" not in token_data:
+        raise ValueError("eBay token response missing access_token or expires_in")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)

--- a/ebay_client/auth/rotation.py
+++ b/ebay_client/auth/rotation.py
@@ -1,0 +1,36 @@
+"""Round-robin credential rotation helpers."""
+
+from __future__ import annotations
+
+from collections.abc import MutableSequence
+from typing import Any
+
+Credential = dict[str, Any]
+
+
+class CredentialRotator:
+    """Track round-robin credential selection and expose the active index."""
+
+    def __init__(
+        self, credentials: MutableSequence[Credential], start_index: int = 0
+    ) -> None:
+        """Create a rotator for a mutable credential sequence."""
+        if not credentials:
+            raise ValueError("At least one eBay credential is required")
+        self._credentials = credentials
+        self.index = start_index % len(credentials)
+
+    @property
+    def index(self) -> int:
+        """Return the index that will be used by the next rotation."""
+        return self._index
+
+    @index.setter
+    def index(self, value: int) -> None:
+        self._index = value % len(self._credentials)
+
+    def next(self) -> Credential:
+        """Return the current credential and advance the index."""
+        credential = self._credentials[self.index]
+        self.index = self.index + 1
+        return credential

--- a/ebay_client/auth/token_store.py
+++ b/ebay_client/auth/token_store.py
@@ -1,0 +1,98 @@
+"""Token persistence helpers for eBay OAuth credentials."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ebay_client.auth.datetime_utils import parse_datetime, serialize_datetime
+
+TokenRecord = dict[str, Any]
+
+
+class EbayTokenStore:
+    """Persist eBay OAuth tokens as JSON keyed by client id."""
+
+    def __init__(self, path: str | Path) -> None:
+        """Create a token store that reads and writes the given JSON file."""
+        self.path = Path(path)
+
+    def load(self) -> dict[str, TokenRecord]:
+        """Load token records from disk, returning an empty mapping if absent."""
+        if not self.path.exists():
+            return {}
+
+        with self.path.open("r", encoding="utf-8") as token_file:
+            raw_records = json.load(token_file)
+
+        if not isinstance(raw_records, Mapping):
+            raise ValueError("Token store must contain an object keyed by client id")
+
+        return {
+            str(client_id): normalize_token_record(record)
+            for client_id, record in raw_records.items()
+        }
+
+    def save(self, records: Mapping[str, Mapping[str, Any]]) -> None:
+        """Persist token records to disk with datetime values serialized."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        serializable = {
+            str(client_id): serialize_token_record(record)
+            for client_id, record in records.items()
+        }
+
+        with self.path.open("w", encoding="utf-8") as token_file:
+            json.dump(serializable, token_file, indent=2, sort_keys=True)
+
+    def update_credential(self, credential: TokenRecord) -> None:
+        """Merge a credential's current token fields into the persisted store."""
+        client_id = credential.get("client_id")
+        if not client_id:
+            raise ValueError("Credential requires client_id before it can be stored")
+
+        records = self.load()
+        records[str(client_id)] = {
+            "token": credential.get("token"),
+            "token_expiry": credential.get("token_expiry"),
+        }
+        self.save(records)
+
+    def apply_to_credentials(self, credentials: list[TokenRecord]) -> None:
+        """Apply persisted token fields to matching credentials in place."""
+        records = self.load()
+        for credential in credentials:
+            record = records.get(str(credential.get("client_id")))
+            if record:
+                credential["token"] = record.get("token")
+                credential["token_expiry"] = record.get("token_expiry")
+
+
+def normalize_token_record(raw_record: object) -> TokenRecord:
+    """Normalize one token record loaded from JSON."""
+    if not isinstance(raw_record, Mapping):
+        raise ValueError("Token records must be objects")
+
+    return {
+        "token": raw_record.get("token"),
+        "token_expiry": parse_datetime(raw_record.get("token_expiry")),
+    }
+
+
+def serialize_token_record(record: Mapping[str, Any]) -> TokenRecord:
+    """Convert one token record into a JSON-serializable mapping."""
+    return {
+        "token": record.get("token"),
+        "token_expiry": serialize_datetime(record.get("token_expiry")),
+    }
+
+
+def load_tokens(path: str | Path) -> dict[str, TokenRecord]:
+    """Load tokens from a JSON file."""
+    return EbayTokenStore(path).load()
+
+
+def save_tokens(path: str | Path, records: Mapping[str, Mapping[str, Any]]) -> None:
+    """Save tokens to a JSON file."""
+    EbayTokenStore(path).save(records)

--- a/ebay_client/config/__init__.py
+++ b/ebay_client/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration helpers for eBay API clients."""
+
+from ebay_client.config.credentials import load_ebay_credentials
+
+__all__ = ["load_ebay_credentials"]

--- a/ebay_client/config/credentials.py
+++ b/ebay_client/config/credentials.py
@@ -1,0 +1,115 @@
+"""Credential loading and normalization for eBay API clients."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from ebay_client.auth.datetime_utils import parse_datetime
+
+Credential = dict[str, Any]
+Environment = Mapping[str, str]
+
+
+def load_ebay_credentials(environ: Environment | None = None) -> list[Credential]:
+    """Load eBay credentials from JSON or single credential environment variables."""
+    env = os.environ if environ is None else environ
+    json_value = _read_non_empty(env, "EBAY_CREDENTIALS_JSON")
+
+    if json_value:
+        return _load_json_credentials(json_value)
+
+    return _load_single_env_credential(env)
+
+
+def normalize_credential(raw_credential: Mapping[str, Any]) -> Credential:
+    """Normalize one credential to the dict shape used by token providers."""
+    client_id = _first_non_empty(
+        raw_credential, "client_id", "clientId", "EBAY_CLIENT_ID"
+    )
+    client_secret = _first_non_empty(
+        raw_credential,
+        "client_secret",
+        "clientSecret",
+        "EBAY_CLIENT_SECRET",
+    )
+
+    if not client_id or not client_secret:
+        raise ValueError("Each eBay credential requires client_id and client_secret")
+
+    normalized = {
+        "client_id": str(client_id),
+        "client_secret": str(client_secret),
+        "token": raw_credential.get("token"),
+        "token_expiry": parse_datetime(raw_credential.get("token_expiry")),
+    }
+
+    if isinstance(raw_credential, dict):
+        raw_credential.update(normalized)
+        return raw_credential
+
+    return normalized
+
+
+def normalize_credentials(raw_credentials: object) -> list[Credential]:
+    """Normalize a JSON credential payload into a list of credential dicts."""
+    if isinstance(raw_credentials, Mapping):
+        return [normalize_credential(raw_credentials)]
+
+    if not isinstance(raw_credentials, list):
+        raise ValueError("EBAY_CREDENTIALS_JSON must be a credential object or list")
+
+    return [_normalize_list_item(credential) for credential in raw_credentials]
+
+
+def _load_json_credentials(json_value: str) -> list[Credential]:
+    try:
+        parsed = json.loads(json_value)
+    except json.JSONDecodeError as exc:
+        raise ValueError("EBAY_CREDENTIALS_JSON contains invalid JSON") from exc
+
+    return normalize_credentials(parsed)
+
+
+def _normalize_list_item(raw_credential: object) -> Credential:
+    if not isinstance(raw_credential, Mapping):
+        raise ValueError("Each EBAY_CREDENTIALS_JSON item must be an object")
+    return normalize_credential(raw_credential)
+
+
+def _load_single_env_credential(env: Environment) -> list[Credential]:
+    client_id = _read_non_empty(env, "EBAY_CLIENT_ID")
+    client_secret = _read_non_empty(env, "EBAY_CLIENT_SECRET")
+
+    if not client_id and not client_secret:
+        return []
+
+    if not client_id or not client_secret:
+        raise ValueError("Both EBAY_CLIENT_ID and EBAY_CLIENT_SECRET are required")
+
+    return [
+        {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "token": None,
+            "token_expiry": None,
+        }
+    ]
+
+
+def _read_non_empty(env: Environment, key: str) -> str | None:
+    value = env.get(key)
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _first_non_empty(raw_credential: Mapping[str, Any], *keys: str) -> Any | None:
+    for key in keys:
+        value = raw_credential.get(key)
+        if value is not None and str(value).strip():
+            return value
+    return None


### PR DESCRIPTION
## Summary
- Add a modular `ebay_client` auth/config package for credential loading, token persistence, datetime parsing, round-robin credential rotation, and OAuth token refresh.
- Preserve `EbayTokenProvider` compatibility through the existing constructor-style inputs, `get_token()`, `_get_token()`, mutable credential dict updates, and `current_cred_index` access.
- Add offline unit coverage for JSON env credentials, single env fallback, empty env, cached-token behavior, token refresh, token-store save/load, store-backed provider loading, and datetime parsing.

## Validation
- PASS: `venv/bin/python -m pytest app/tests/test_ebay_auth_config.py`
- PASS: `venv/bin/python -m mypy ebay_client`
- FAIL (pre-existing suite collection issues): `venv/bin/python -m pytest` fails on missing legacy imports (`Query`, `archive_items`, `load_historical_items`, `cancel_subscription_logic`) and missing `ENCRYPTION_KEY` in `app/tests/test_telegram_notification.py`.
- FAIL (pre-existing formatting debt): `venv/bin/python -m black . --check` reports 51 existing files outside this PR would be reformatted. Scoped files were formatted with `venv/bin/python -m black ebay_client app/tests/test_ebay_auth_config.py`.
- FAIL (pre-existing typing debt): `venv/bin/python -m mypy .` reports existing missing stubs/model attribute errors outside `ebay_client`; `ebay_client` itself passes.

No matching GitHub issue was found for this AO assignment, so this PR does not auto-close an issue.
