### PR TITLE
refactor: modularize eBay Browse client orchestration

### DIFF
--- a/app/tests/test_ebay_browse_client.py
+++ b/app/tests/test_ebay_browse_client.py
@@ -1,0 +1,202 @@
+from typing import Mapping, Optional, TypedDict
+
+from ebay_client.browse.client import EbayBrowseClient
+
+
+class RecordedCall(TypedDict):
+    """Captured GET call details."""
+
+    url: str
+    headers: dict[str, str]
+    params: dict[str, object]
+
+
+class FakeTokenProvider:
+    """Token provider used by offline Browse client tests."""
+
+    def __init__(self, token: str = "test-token") -> None:
+        self.token = token
+
+    def get_token(self) -> str:
+        """Return the configured fake token."""
+        return self.token
+
+
+class FakeResponse:
+    """Small response double with the parts used by EbayBrowseClient."""
+
+    def __init__(
+        self,
+        status_code: int = 200,
+        json_data: Optional[dict[str, object]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        self.status_code = status_code
+        self._json_data = json_data or {}
+        self.headers = dict(headers or {})
+
+    def json(self) -> dict[str, object]:
+        """Return the fake JSON payload."""
+        return self._json_data
+
+    def raise_for_status(self) -> None:
+        """Raise a runtime error for non-successful fake responses."""
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class RecordingSession:
+    """Session double that records GET requests and returns queued responses."""
+
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self.responses = responses
+        self.calls: list[RecordedCall] = []
+
+    def mount(self, prefix: str, adapter: object) -> None:
+        """Accept adapter mounting to match requests.Session."""
+
+    def get(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        params: Mapping[str, object],
+    ) -> FakeResponse:
+        """Record a GET call and return the next fake response."""
+        self.calls.append(
+            {
+                "url": url,
+                "headers": dict(headers),
+                "params": dict(params),
+            }
+        )
+        return self.responses.pop(0)
+
+
+def item_summary(item_id: str) -> dict[str, object]:
+    """Build a minimal item summary payload for parser-driven tests."""
+    return {
+        "itemId": item_id,
+        "title": f"Item {item_id}",
+        "price": {"value": "10.00", "currency": "GBP"},
+    }
+
+
+def test_search_item_summaries_sends_headers_and_params() -> None:
+    session = RecordingSession([FakeResponse(json_data={"itemSummaries": []})])
+    client = EbayBrowseClient(FakeTokenProvider(), session=session)
+
+    client.search_item_summaries(
+        "charizard",
+        filters={"min_price": 10, "item_location": "any"},
+        limit=25,
+        offset=50,
+        sort_order="price",
+    )
+
+    call = session.calls[0]
+    assert call["url"] == "https://api.ebay.com/buy/browse/v1/item_summary/search"
+    assert call["headers"] == {
+        "Authorization": "Bearer test-token",
+        "X-EBAY-C-MARKETPLACE-ID": "EBAY-GB",
+        "X-EBAY-C-CURRENCY": "GBP",
+        "Content-Language": "en-GB",
+        "Accept-Language": "en-GB",
+        "Content-Type": "application/json",
+    }
+    assert call["params"] == {
+        "q": "charizard",
+        "limit": 25,
+        "offset": 50,
+        "sort": "price",
+        "filter": "priceCurrency:GBP,price:[10..]",
+    }
+
+
+def test_search_item_summaries_applies_marketplace_override() -> None:
+    session = RecordingSession([FakeResponse(json_data={"itemSummaries": []})])
+    client = EbayBrowseClient(FakeTokenProvider(), session=session)
+
+    client.search_item_summaries("laptop", marketplace="EBAY_US")
+
+    headers = session.calls[0]["headers"]
+    assert client.marketplace == "EBAY_US"
+    assert client.country_code == "US"
+    assert client.currency == "USD"
+    assert headers["X-EBAY-C-MARKETPLACE-ID"] == "EBAY-US"
+    assert headers["X-EBAY-C-CURRENCY"] == "USD"
+    assert headers["Content-Language"] == "en-US"
+
+
+def test_search_item_summaries_retries_429_once_after_retry_after() -> None:
+    session = RecordingSession(
+        [
+            FakeResponse(status_code=429, headers={"Retry-After": "7"}),
+            FakeResponse(json_data={"itemSummaries": []}),
+        ]
+    )
+    sleep_calls: list[float] = []
+    client = EbayBrowseClient(
+        FakeTokenProvider(),
+        session=session,
+        retry_sleep=sleep_calls.append,
+    )
+
+    client.search_item_summaries("pikachu")
+
+    assert len(session.calls) == 2
+    assert sleep_calls == [7]
+
+
+def test_search_items_stops_after_short_page() -> None:
+    session = RecordingSession(
+        [
+            FakeResponse(
+                json_data={
+                    "itemSummaries": [item_summary(str(index)) for index in range(199)]
+                }
+            ),
+            FakeResponse(json_data={"itemSummaries": [item_summary("extra")]}),
+        ]
+    )
+    client = EbayBrowseClient(
+        FakeTokenProvider(),
+        session=session,
+        page_sleep=lambda seconds: None,
+    )
+
+    items = client.search_items("books", max_pages=None)
+
+    assert len(items) == 199
+    assert len(session.calls) == 1
+
+
+def test_search_items_dedupes_across_pages() -> None:
+    session = RecordingSession(
+        [
+            FakeResponse(
+                json_data={
+                    "itemSummaries": [item_summary(str(index)) for index in range(200)]
+                }
+            ),
+            FakeResponse(
+                json_data={
+                    "itemSummaries": [
+                        item_summary("5"),
+                        item_summary("200"),
+                    ]
+                }
+            ),
+        ]
+    )
+    client = EbayBrowseClient(
+        FakeTokenProvider(),
+        session=session,
+        page_sleep=lambda seconds: None,
+    )
+
+    items = client.search_items("books", max_pages=None)
+
+    assert len(items) == 201
+    assert [item["ebay_id"] for item in items].count("5") == 1
+    assert session.calls[1]["params"]["offset"] == 200

--- a/ebay_client/browse/__init__.py
+++ b/ebay_client/browse/__init__.py
@@ -1,0 +1,13 @@
+from ebay_client.browse.client import EbayBrowseClient
+from ebay_client.browse.dto import SearchFilters, SearchRequest
+from ebay_client.browse.filters import SearchFilterBuilder, build_search_filter
+from ebay_client.browse.parsers import parse_item_summary_response
+
+__all__ = [
+    "EbayBrowseClient",
+    "SearchFilterBuilder",
+    "SearchFilters",
+    "SearchRequest",
+    "build_search_filter",
+    "parse_item_summary_response",
+]

--- a/ebay_client/browse/client.py
+++ b/ebay_client/browse/client.py
@@ -1,0 +1,137 @@
+import logging
+import time
+from typing import Callable, Mapping, Optional, cast
+
+import requests
+
+from ebay_client.browse.dto import SearchFilters
+from ebay_client.browse.filters import SearchFilterBuilder
+from ebay_client.browse.headers import build_browse_headers
+from ebay_client.browse.pagination import collect_unique_paginated_items
+from ebay_client.browse.parsers import parse_item_summary_response
+from ebay_client.browse.request_params import (
+    build_search_params,
+    create_search_request,
+)
+from ebay_client.browse.retry import BrowseSession, get_with_rate_limit_retry
+from ebay_client.marketplaces import get_marketplace
+
+logger = logging.getLogger(__name__)
+DEFAULT_SEARCH_LIMIT = 200
+
+
+class EbayBrowseClient:
+    """Official eBay Browse API client."""
+
+    token_url = "https://api.ebay.com/identity/v1/oauth2/token"
+    base_url = "https://api.ebay.com/buy/browse/v1"
+
+    def __init__(
+        self,
+        token_provider,
+        marketplace: str = "EBAY_GB",
+        session=None,
+        retry_sleep: Callable[[float], None] = time.sleep,
+        page_sleep: Callable[[float], None] = time.sleep,
+        max_rate_limit_retries: int = 1,
+    ) -> None:
+        self.token_provider = token_provider
+        self.marketplace = marketplace
+        self.session = session or requests.Session()
+        self.retry_sleep = retry_sleep
+        self.page_sleep = page_sleep
+        self.max_rate_limit_retries = max_rate_limit_retries
+
+        adapter = requests.adapters.HTTPAdapter(
+            pool_connections=30,
+            pool_maxsize=200,
+            max_retries=3,
+        )
+        self.session.mount("https://", adapter)
+        self._set_marketplace_config(marketplace)
+
+    def _set_marketplace_config(self, marketplace: str) -> None:
+        self.marketplace = marketplace
+        self.marketplace_config = get_marketplace(marketplace)
+        self.country_code = self.marketplace_config.location
+        self.currency = self.marketplace_config.currency
+
+    def search_item_summaries(
+        self,
+        keywords: str,
+        filters: Optional[Mapping[str, object]] = None,
+        limit: int = DEFAULT_SEARCH_LIMIT,
+        offset: int = 0,
+        sort_order: Optional[str] = None,
+        marketplace: Optional[str] = None,
+    ) -> dict[str, object]:
+        """Search eBay item summaries and return the raw Browse API response."""
+        if marketplace:
+            self._set_marketplace_config(marketplace)
+
+        request = create_search_request(
+            keywords=keywords,
+            filters=filters,
+            limit=limit,
+            offset=offset,
+            sort_order=sort_order,
+        )
+        token = self.token_provider.get_token()
+        headers = build_browse_headers(
+            token=token,
+            marketplace=self.marketplace,
+            marketplace_config=self.marketplace_config,
+        )
+        params = build_search_params(
+            request=request,
+            filter_value=self.build_filter(request.filters),
+        )
+        response = get_with_rate_limit_retry(
+            cast(BrowseSession, self.session),
+            f"{self.base_url}/item_summary/search",
+            headers,
+            params,
+            max_retries=self.max_rate_limit_retries,
+            sleeper=self.retry_sleep,
+        )
+        return response.json()
+
+    def search_items(
+        self,
+        keywords: str,
+        filters: Optional[Mapping[str, object]] = None,
+        sort_order: Optional[str] = None,
+        max_pages: Optional[int] = 1,
+        marketplace: Optional[str] = None,
+    ) -> list[dict[str, object]]:
+        """Search and parse eBay items across pages, returning deduplicated items."""
+        if marketplace:
+            self._set_marketplace_config(marketplace)
+
+        def fetch_page(offset: int) -> dict[str, object]:
+            return self.search_item_summaries(
+                keywords=keywords,
+                filters=filters,
+                limit=DEFAULT_SEARCH_LIMIT,
+                offset=offset,
+                sort_order=sort_order,
+            )
+
+        return collect_unique_paginated_items(
+            fetch_page=fetch_page,
+            parse_page=self.parse_item_summary_response,
+            max_pages=max_pages,
+            page_size=DEFAULT_SEARCH_LIMIT,
+            sleeper=self.page_sleep,
+        )
+
+    def build_filter(self, filters: SearchFilters) -> str:
+        """Build a Browse API filter expression for search filters."""
+        return SearchFilterBuilder(self.currency).build(filters)
+
+    def parse_item_summary_response(
+        self,
+        response: Mapping[str, object],
+    ) -> list[dict[str, object]]:
+        """Parse a raw item summary response using the active marketplace currency."""
+        return parse_item_summary_response(response, default_currency=self.currency)

--- a/ebay_client/browse/dto.py
+++ b/ebay_client/browse/dto.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class SearchFilters:
+    min_price: Optional[float] = None
+    max_price: Optional[float] = None
+    item_location: Optional[str] = "GB"
+    condition: Optional[str] = None
+    buying_options: str = "FIXED_PRICE|AUCTION"
+
+    @classmethod
+    def from_mapping(cls, filters):
+        filters = filters or {}
+        return cls(
+            min_price=filters.get("min_price"),
+            max_price=filters.get("max_price"),
+            item_location=filters.get("item_location"),
+            condition=filters.get("condition"),
+            buying_options=filters.get("buying_options", "FIXED_PRICE|AUCTION"),
+        )
+
+
+@dataclass(frozen=True)
+class SearchRequest:
+    keywords: str
+    filters: SearchFilters
+    limit: int = 200
+    offset: int = 0
+    sort_order: Optional[str] = None

--- a/ebay_client/browse/filters.py
+++ b/ebay_client/browse/filters.py
@@ -1,0 +1,42 @@
+from ebay_client.browse.dto import SearchFilters
+
+
+class SearchFilterBuilder:
+    def __init__(self, currency):
+        self.currency = currency
+
+    def build(self, filters):
+        filters = (
+            SearchFilters.from_mapping(filters)
+            if isinstance(filters, dict)
+            else filters
+        )
+        filter_parts = []
+
+        item_location = filters.item_location
+        if item_location and item_location != "any":
+            filter_parts.append(f"itemLocationCountry:{item_location}")
+
+        if filters.buying_options != "FIXED_PRICE|AUCTION":
+            filter_parts.append(f"buyingOptions:{{{filters.buying_options}}}")
+
+        if filters.condition in ["NEW", "USED"]:
+            filter_parts.append(f"conditions:{{{filters.condition}}}")
+
+        if filters.min_price or filters.max_price:
+            filter_parts.append(f"priceCurrency:{self.currency}")
+
+        if filters.min_price is not None or filters.max_price is not None:
+            if filters.min_price is not None and filters.max_price is not None:
+                price_range = f"{filters.min_price}..{filters.max_price}"
+            elif filters.min_price is not None:
+                price_range = f"{filters.min_price}.."
+            else:
+                price_range = f"..{filters.max_price}"
+            filter_parts.append(f"price:[{price_range}]")
+
+        return ",".join(filter_parts)
+
+
+def build_search_filter(filters, currency):
+    return SearchFilterBuilder(currency).build(filters)

--- a/ebay_client/browse/headers.py
+++ b/ebay_client/browse/headers.py
@@ -1,0 +1,22 @@
+from ebay_client.marketplaces import Marketplace
+
+
+def format_marketplace_header(marketplace: str) -> str:
+    """Return the eBay marketplace header value for an internal marketplace code."""
+    return marketplace.replace("_", "-")
+
+
+def build_browse_headers(
+    token: str,
+    marketplace: str,
+    marketplace_config: Marketplace,
+) -> dict[str, str]:
+    """Build headers required by eBay Browse API search requests."""
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-EBAY-C-MARKETPLACE-ID": format_marketplace_header(marketplace),
+        "X-EBAY-C-CURRENCY": marketplace_config.currency,
+        "Content-Language": marketplace_config.language,
+        "Accept-Language": marketplace_config.language,
+        "Content-Type": "application/json",
+    }

--- a/ebay_client/browse/pagination.py
+++ b/ebay_client/browse/pagination.py
@@ -1,0 +1,37 @@
+import time
+from typing import Callable, Mapping, Optional
+
+from ebay_client.browse.responses import dedupe_items
+
+FetchPage = Callable[[int], Mapping[str, object]]
+ParsePage = Callable[[Mapping[str, object]], list[dict[str, object]]]
+Sleeper = Callable[[float], None]
+
+
+def collect_unique_paginated_items(
+    fetch_page: FetchPage,
+    parse_page: ParsePage,
+    *,
+    max_pages: Optional[int],
+    page_size: int,
+    page_delay_seconds: float = 1,
+    sleeper: Optional[Sleeper] = None,
+) -> list[dict[str, object]]:
+    """Collect paginated Browse items until max pages or a short page is reached."""
+    returned_items: list[dict[str, object]] = []
+    pages_searched = 0
+    offset = 0
+    sleep = sleeper or time.sleep
+
+    while max_pages is None or pages_searched < max_pages:
+        sleep(page_delay_seconds)
+        raw_response = fetch_page(offset)
+        parsed_items = parse_page(raw_response)
+        returned_items.extend(parsed_items)
+
+        pages_searched += 1
+        offset += len(parsed_items)
+        if len(parsed_items) < page_size:
+            break
+
+    return dedupe_items(returned_items)

--- a/ebay_client/browse/parsers.py
+++ b/ebay_client/browse/parsers.py
@@ -1,0 +1,90 @@
+import json
+
+from ebay_client.time import parse_ebay_datetime
+
+
+def parse_item_summary_response(response, default_currency="GBP"):
+    items = []
+    for item_data in response.get("itemSummaries", []):
+        price_info = item_data.get("price", {})
+        base_price = {
+            "value": float(price_info.get("value", 0)),
+            "currency": price_info.get("currency", default_currency),
+        }
+
+        raw_buying_options = item_data.get("buyingOptions", [])
+        is_auction = "AUCTION" in raw_buying_options
+        auction_data = (
+            {
+                "bid_count": item_data.get("bidCount", 0),
+                "current_bid": {
+                    "value": float(
+                        item_data.get("currentBidPrice", {}).get("value", 0)
+                    ),
+                    "currency": item_data.get("currentBidPrice", {}).get(
+                        "currency", default_currency
+                    ),
+                },
+                "end_time": item_data.get("itemEndDate"),
+                "marketplace_id": item_data.get("listingMarketplaceId"),
+            }
+            if is_auction
+            else None
+        )
+
+        items.append(
+            {
+                "ebay_id": item_data.get("itemId"),
+                "legacy_id": item_data.get("legacyItemId"),
+                "title": item_data.get("title", "No Title"),
+                "price": base_price["value"],
+                "current_bid": (
+                    auction_data["current_bid"]["value"]
+                    if auction_data and "current_bid" in auction_data
+                    else 0
+                ),
+                "current_bid_currency": (
+                    auction_data["current_bid"]["currency"]
+                    if auction_data and "current_bid" in auction_data
+                    else base_price.get("currency", default_currency)
+                ),
+                "currency": base_price["currency"],
+                "url": item_data.get("itemWebUrl"),
+                "image_url": item_data.get("image", {}).get("imageUrl"),
+                "seller": item_data.get("seller", {}).get("username"),
+                "seller_rating": item_data.get("seller", {}).get("feedbackPercentage"),
+                "condition": item_data.get("condition"),
+                "location": {
+                    "country": item_data.get("itemLocation", {}).get("country"),
+                    "postal_code": item_data.get("itemLocation", {}).get("postalCode"),
+                },
+                "start_time": parse_ebay_datetime(item_data.get("itemCreationDate")),
+                "end_time": parse_ebay_datetime(item_data.get("itemEndDate")),
+                "buying_options": json.dumps(raw_buying_options),
+                "auction_details": json.dumps(auction_data) if auction_data else None,
+                "categories": json.dumps(
+                    {
+                        "ids": [
+                            category["categoryId"]
+                            for category in item_data.get("categories", [])
+                        ],
+                        "names": [
+                            category["categoryName"]
+                            for category in item_data.get("categories", [])
+                        ],
+                    }
+                ),
+                "marketplace": item_data.get("listingMarketplaceId"),
+                "images": json.dumps(
+                    {
+                        "main": item_data.get("image", {}).get("imageUrl"),
+                        "thumbnails": [
+                            image.get("imageUrl")
+                            for image in item_data.get("thumbnailImages", [])
+                        ],
+                    }
+                ),
+            }
+        )
+
+    return items

--- a/ebay_client/browse/request_params.py
+++ b/ebay_client/browse/request_params.py
@@ -1,0 +1,40 @@
+from typing import Mapping, Optional
+
+from ebay_client.browse.dto import SearchFilters, SearchRequest
+
+
+def create_search_request(
+    keywords: str,
+    filters: Optional[Mapping[str, object]],
+    limit: int,
+    offset: int,
+    sort_order: Optional[str],
+) -> SearchRequest:
+    """Create a normalized search request from public client arguments."""
+    return SearchRequest(
+        keywords=keywords,
+        filters=SearchFilters.from_mapping(filters),
+        limit=limit,
+        offset=offset,
+        sort_order=sort_order,
+    )
+
+
+def build_search_params(
+    request: SearchRequest,
+    filter_value: Optional[str],
+) -> dict[str, object]:
+    """Build query parameters for an item summary search request."""
+    params: dict[str, object] = {
+        "q": request.keywords,
+        "limit": request.limit,
+        "offset": request.offset,
+    }
+
+    if request.sort_order:
+        params["sort"] = request.sort_order
+
+    if filter_value:
+        params["filter"] = filter_value
+
+    return params

--- a/ebay_client/browse/responses.py
+++ b/ebay_client/browse/responses.py
@@ -1,0 +1,12 @@
+def dedupe_items(items):
+    seen_ids = set()
+    unique_items = []
+    for item in items:
+        item_id = item.get("ebay_id")
+        if item_id:
+            if item_id not in seen_ids:
+                seen_ids.add(item_id)
+                unique_items.append(item)
+        else:
+            unique_items.append(item)
+    return unique_items

--- a/ebay_client/browse/retry.py
+++ b/ebay_client/browse/retry.py
@@ -1,0 +1,66 @@
+import time
+from typing import Callable, Mapping, Optional, Protocol
+
+DEFAULT_RETRY_AFTER_SECONDS = 60
+
+
+class BrowseResponse(Protocol):
+    """Small response protocol used by the browse retry helper."""
+
+    status_code: int
+    headers: Mapping[str, str]
+
+    def json(self) -> dict[str, object]:
+        """Return a decoded JSON response body."""
+
+    def raise_for_status(self) -> None:
+        """Raise an HTTP error if the response is unsuccessful."""
+
+
+class BrowseSession(Protocol):
+    """Small session protocol used by the browse retry helper."""
+
+    def get(
+        self,
+        url: str,
+        headers: Mapping[str, str],
+        params: Mapping[str, object],
+    ) -> BrowseResponse:
+        """Issue a GET request."""
+
+
+Sleeper = Callable[[float], None]
+
+
+def parse_retry_after(
+    headers: Mapping[str, str],
+    default_seconds: int = DEFAULT_RETRY_AFTER_SECONDS,
+) -> int:
+    """Parse Retry-After seconds, falling back to a conservative default."""
+    try:
+        return int(headers.get("Retry-After", default_seconds))
+    except (TypeError, ValueError):
+        return default_seconds
+
+
+def get_with_rate_limit_retry(
+    session: BrowseSession,
+    url: str,
+    headers: Mapping[str, str],
+    params: Mapping[str, object],
+    *,
+    max_retries: int = 1,
+    sleeper: Optional[Sleeper] = None,
+) -> BrowseResponse:
+    """GET a Browse API URL and retry bounded 429 responses after Retry-After."""
+    response = session.get(url, headers=headers, params=params)
+    retries_used = 0
+    sleep = sleeper or time.sleep
+
+    while response.status_code == 429 and retries_used < max_retries:
+        sleep(parse_retry_after(response.headers))
+        retries_used += 1
+        response = session.get(url, headers=headers, params=params)
+
+    response.raise_for_status()
+    return response

--- a/ebay_client/marketplaces.py
+++ b/ebay_client/marketplaces.py
@@ -1,0 +1,136 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Marketplace:
+    code: str
+    location: str
+    country: str
+    site: str
+    currency: str
+    language: str
+
+    @classmethod
+    def from_mapping(cls, data):
+        return cls(
+            code=data["code"],
+            location=data["location"],
+            country=data["country"],
+            site=data["site"],
+            currency=data["currency"],
+            language=data["language"],
+        )
+
+    def as_dict(self):
+        return {
+            "code": self.code,
+            "location": self.location,
+            "country": self.country,
+            "site": self.site,
+            "currency": self.currency,
+            "language": self.language,
+        }
+
+
+MARKETPLACES = {
+    "EBAY_GB": Marketplace(
+        code="EBAY_GB",
+        location="GB",
+        country="United Kingdom",
+        site="ebay.co.uk",
+        currency="GBP",
+        language="en-GB",
+    ),
+    "EBAY_US": Marketplace(
+        code="EBAY_US",
+        location="US",
+        country="United States",
+        site="ebay.com",
+        currency="USD",
+        language="en-US",
+    ),
+    "EBAY_DE": Marketplace(
+        code="EBAY_DE",
+        location="DE",
+        country="Germany",
+        site="ebay.de",
+        currency="EUR",
+        language="de-DE",
+    ),
+    "EBAY_CA": Marketplace(
+        code="EBAY_CA",
+        location="CA",
+        country="Canada",
+        site="ebay.ca",
+        currency="CAD",
+        language="en-CA",
+    ),
+    "EBAY_AU": Marketplace(
+        code="EBAY_AU",
+        location="AU",
+        country="Australia",
+        site="ebay.com.au",
+        currency="AUD",
+        language="en-AU",
+    ),
+    "EBAY_FR": Marketplace(
+        code="EBAY_FR",
+        location="FR",
+        country="France",
+        site="ebay.fr",
+        currency="EUR",
+        language="fr-FR",
+    ),
+    "EBAY_IT": Marketplace(
+        code="EBAY_IT",
+        location="IT",
+        country="Italy",
+        site="ebay.it",
+        currency="EUR",
+        language="it-IT",
+    ),
+    "EBAY_ES": Marketplace(
+        code="EBAY_ES",
+        location="ES",
+        country="Spain",
+        site="ebay.es",
+        currency="EUR",
+        language="es-ES",
+    ),
+    "EBAY_NL": Marketplace(
+        code="EBAY_NL",
+        location="NL",
+        country="Netherlands",
+        site="ebay.nl",
+        currency="EUR",
+        language="nl-NL",
+    ),
+    "EBAY_PL": Marketplace(
+        code="EBAY_PL",
+        location="PL",
+        country="Poland",
+        site="ebay.pl",
+        currency="PLN",
+        language="pl-PL",
+    ),
+    "EBAY_ANY": Marketplace(
+        code="EBAY_ANY",
+        location="any",
+        country="ANY",
+        site="ebay.com",
+        currency="USD",
+        language="en-US",
+    ),
+}
+
+
+MARKETPLACE_IDS = {
+    code: marketplace.as_dict() for code, marketplace in MARKETPLACES.items()
+}
+
+
+def get_marketplace(code, default="EBAY_GB"):
+    return MARKETPLACES.get(code, MARKETPLACES[default])
+
+
+__all__ = ["MARKETPLACE_IDS", "MARKETPLACES", "Marketplace", "get_marketplace"]

--- a/ebay_client/time.py
+++ b/ebay_client/time.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timezone
+
+
+def parse_ebay_datetime(value):
+    if not value:
+        return None
+
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError:
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None


### PR DESCRIPTION
## Summary
- Extract Browse client header, request parameter, bounded 429 retry, and pagination/dedupe responsibilities into focused helper modules.
- Keep `EbayBrowseClient` public methods for item summary search, parsed item search, filter building, and response parsing.
- Add offline tests for request headers/params, marketplace override, Retry-After retry handling, pagination stop behavior, and cross-page dedupe.

No GitHub issue number was provided in the AO assignment, so this PR does not auto-close an issue.

## Tests
- `black .` ran; it reformatted unrelated legacy files, so that formatting churn was reverted and the new browse files were formatted with `black ebay_client app/tests/test_ebay_browse_client.py`.
- `pytest --noconftest app/tests/test_ebay_browse_client.py` passes: 5 passed.
- `pytest` currently fails during legacy test collection before running tests due existing app/test issues: missing `Query`, missing `archive_items`/`load_historical_items`, missing `cancel_subscription_logic`, and missing `ENCRYPTION_KEY`.
- `mypy .` currently fails on existing untyped Flask/app code and the same legacy missing symbols. Scoped check `mypy ebay_client/browse ebay_client/marketplaces.py ebay_client/time.py` passes.