### PR TITLE
[codex] Refactor browse filter builder helpers

### DIFF
--- a/app/tests/test_ebay_browse_filters.py
+++ b/app/tests/test_ebay_browse_filters.py
@@ -1,0 +1,109 @@
+from typing import Optional
+
+import pytest
+
+from ebay_client.browse.dto import SearchFilters
+from ebay_client.browse.filters import SearchFilterBuilder, build_search_filter
+
+
+@pytest.fixture
+def builder() -> SearchFilterBuilder:
+    return SearchFilterBuilder("GBP")
+
+
+@pytest.mark.parametrize(
+    ("condition", "expected"),
+    [
+        ("NEW", "itemLocationCountry:GB,conditions:{NEW}"),
+        ("USED", "itemLocationCountry:GB,conditions:{USED}"),
+        ("", "itemLocationCountry:GB"),
+        ("RENEWED", "itemLocationCountry:GB"),
+    ],
+)
+def test_condition_filters(
+    builder: SearchFilterBuilder, condition: str, expected: str
+) -> None:
+    filters = SearchFilters(condition=condition)
+
+    assert builder.build(filters) == expected
+
+
+@pytest.mark.parametrize(
+    ("buying_options", "expected"),
+    [
+        ("FIXED_PRICE|AUCTION", "itemLocationCountry:GB"),
+        ("FIXED_PRICE", "itemLocationCountry:GB,buyingOptions:{FIXED_PRICE}"),
+        ("AUCTION", "itemLocationCountry:GB,buyingOptions:{AUCTION}"),
+    ],
+)
+def test_buying_options_filters(
+    builder: SearchFilterBuilder, buying_options: str, expected: str
+) -> None:
+    filters = SearchFilters(buying_options=buying_options)
+
+    assert builder.build(filters) == expected
+
+
+@pytest.mark.parametrize(
+    ("item_location", "expected"),
+    [
+        ("GB", "itemLocationCountry:GB"),
+        ("US", "itemLocationCountry:US"),
+        ("any", ""),
+        (None, ""),
+    ],
+)
+def test_location_filters(
+    builder: SearchFilterBuilder, item_location: Optional[str], expected: str
+) -> None:
+    filters = SearchFilters(item_location=item_location)
+
+    assert builder.build(filters) == expected
+
+
+@pytest.mark.parametrize(
+    ("filters", "expected"),
+    [
+        (
+            SearchFilters(min_price=10, max_price=50, item_location="any"),
+            "priceCurrency:GBP,price:[10..50]",
+        ),
+        (
+            SearchFilters(min_price=10, item_location="any"),
+            "priceCurrency:GBP,price:[10..]",
+        ),
+        (
+            SearchFilters(max_price=50, item_location="any"),
+            "priceCurrency:GBP,price:[..50]",
+        ),
+        (
+            SearchFilters(min_price=0, item_location="any"),
+            "price:[0..]",
+        ),
+    ],
+)
+def test_price_range_filters(
+    builder: SearchFilterBuilder, filters: SearchFilters, expected: str
+) -> None:
+    assert builder.build(filters) == expected
+
+
+def test_dict_and_search_filters_input_build_same_filter() -> None:
+    mapping_filters = {
+        "min_price": 10,
+        "max_price": 20,
+        "item_location": "US",
+        "condition": "USED",
+        "buying_options": "AUCTION",
+    }
+    search_filters = SearchFilters(
+        min_price=10,
+        max_price=20,
+        item_location="US",
+        condition="USED",
+        buying_options="AUCTION",
+    )
+
+    assert build_search_filter(mapping_filters, "USD") == build_search_filter(
+        search_filters, "USD"
+    )

--- a/ebay_client/browse/filters.py
+++ b/ebay_client/browse/filters.py
@@ -1,38 +1,72 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional, Union
+
 from ebay_client.browse.dto import SearchFilters
+
+DEFAULT_BUYING_OPTIONS = "FIXED_PRICE|AUCTION"
+VALID_CONDITIONS = {"NEW", "USED"}
+SearchFilterInput = Union[SearchFilters, Mapping[str, Any]]
 
 
 class SearchFilterBuilder:
-    def __init__(self, currency):
+    """Build eBay Browse API filter strings from search filters."""
+
+    def __init__(self, currency: str) -> None:
         self.currency = currency
 
-    def build(self, filters):
-        filters = SearchFilters.from_mapping(filters) if isinstance(filters, dict) else filters
-        filter_parts = []
+    def build(self, filters: SearchFilterInput) -> str:
+        """Return the eBay Browse API filter string for the given filters."""
+        search_filters = self._normalize_filters(filters)
+        filter_parts = [
+            self._location_filter(search_filters),
+            self._buying_options_filter(search_filters),
+            self._condition_filter(search_filters),
+            self._currency_filter(search_filters),
+            self._price_range_filter(search_filters),
+        ]
 
+        return ",".join(filter_part for filter_part in filter_parts if filter_part)
+
+    def _normalize_filters(self, filters: SearchFilterInput) -> SearchFilters:
+        if isinstance(filters, Mapping):
+            return SearchFilters.from_mapping(filters)
+        return filters
+
+    def _location_filter(self, filters: SearchFilters) -> Optional[str]:
         item_location = filters.item_location
         if item_location and item_location != "any":
-            filter_parts.append(f"itemLocationCountry:{item_location}")
+            return f"itemLocationCountry:{item_location}"
+        return None
 
-        if filters.buying_options != "FIXED_PRICE|AUCTION":
-            filter_parts.append(f"buyingOptions:{{{filters.buying_options}}}")
+    def _buying_options_filter(self, filters: SearchFilters) -> Optional[str]:
+        if filters.buying_options != DEFAULT_BUYING_OPTIONS:
+            return f"buyingOptions:{{{filters.buying_options}}}"
+        return None
 
-        if filters.condition in ["NEW", "USED"]:
-            filter_parts.append(f"conditions:{{{filters.condition}}}")
+    def _condition_filter(self, filters: SearchFilters) -> Optional[str]:
+        if filters.condition in VALID_CONDITIONS:
+            return f"conditions:{{{filters.condition}}}"
+        return None
 
+    def _currency_filter(self, filters: SearchFilters) -> Optional[str]:
         if filters.min_price or filters.max_price:
-            filter_parts.append(f"priceCurrency:{self.currency}")
+            return f"priceCurrency:{self.currency}"
+        return None
 
+    def _price_range_filter(self, filters: SearchFilters) -> Optional[str]:
         if filters.min_price is not None or filters.max_price is not None:
-            if filters.min_price is not None and filters.max_price is not None:
-                price_range = f"{filters.min_price}..{filters.max_price}"
-            elif filters.min_price is not None:
-                price_range = f"{filters.min_price}.."
-            else:
-                price_range = f"..{filters.max_price}"
-            filter_parts.append(f"price:[{price_range}]")
+            return f"price:[{self._format_price_range(filters)}]"
+        return None
 
-        return ",".join(filter_parts)
+    def _format_price_range(self, filters: SearchFilters) -> str:
+        if filters.min_price is not None and filters.max_price is not None:
+            return f"{filters.min_price}..{filters.max_price}"
+        if filters.min_price is not None:
+            return f"{filters.min_price}.."
+        return f"..{filters.max_price}"
 
 
-def build_search_filter(filters, currency):
+def build_search_filter(filters: SearchFilterInput, currency: str) -> str:
+    """Build an eBay Browse API filter string using the given currency."""
     return SearchFilterBuilder(currency).build(filters)


### PR DESCRIPTION
## Summary
- Split `SearchFilterBuilder.build` into focused helpers for filter normalization, location, buying options, condition, currency, and price ranges.
- Kept `SearchFilterBuilder(currency).build(filters)` and `build_search_filter(filters, currency)` public APIs intact.
- Added offline coverage for condition, buying options, location, price ranges, and dict vs `SearchFilters` input behavior.

Closes #12

## Validation
- `uv run --python 3.11 --with-requirements requirements.txt pytest app/tests/test_ebay_browse_filters.py` passes: 16 passed.
- `uv run --python 3.11 --with-requirements requirements.txt --with black black .` ran; it reformatted broad pre-existing files, so those unrelated formatter-only changes were reverted and the scoped files were checked with `black ebay_client/browse/filters.py app/tests/test_ebay_browse_filters.py`.
- `uv run --python 3.11 --with-requirements requirements.txt pytest` currently fails during collection on existing unrelated issues: missing `Query` in `app.models`, missing `archive_items`/`load_historical_items`, missing `cancel_subscription_logic`, and missing `ENCRYPTION_KEY` for `test_telegram_notification.py`.
- `uv run --python 3.11 --with-requirements requirements.txt --with mypy mypy .` currently fails on existing missing stubs and unrelated app/test typing errors.
