### PR TITLE
[codex] Refactor eBay Browse client helpers

### DIFF
--- a/app/tests/test_ebay_browse_client.py
+++ b/app/tests/test_ebay_browse_client.py
@@ -1,0 +1,207 @@
+from typing import Any
+
+from ebay_client.browse.client import EbayBrowseClient
+
+
+class FakeTokenProvider:
+    """Token provider that avoids live eBay auth in Browse client tests."""
+
+    def __init__(self, token: str = "test-token") -> None:
+        self.token = token
+
+    def get_token(self) -> str:
+        """Return a deterministic OAuth token."""
+        return self.token
+
+
+class FakeResponse:
+    """Minimal response object for offline Browse client tests."""
+
+    def __init__(
+        self,
+        *,
+        json_data: dict[str, Any],
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self._json_data = json_data
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def json(self) -> dict[str, Any]:
+        """Return the configured response body."""
+        return self._json_data
+
+    def raise_for_status(self) -> None:
+        """Raise for HTTP errors."""
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class FakeSession:
+    """Requests-like session that records outgoing calls."""
+
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    def get(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        params: dict[str, str | int],
+    ) -> FakeResponse:
+        """Record a GET call and return the next fake response."""
+        self.calls.append({"url": url, "headers": headers, "params": params})
+        return self.responses.pop(0)
+
+
+def fake_item(item_id: str) -> dict[str, Any]:
+    """Build a minimal eBay item summary accepted by the parser."""
+    return {
+        "itemId": item_id,
+        "title": f"Item {item_id}",
+        "price": {"value": "12.50", "currency": "GBP"},
+        "buyingOptions": ["FIXED_PRICE"],
+    }
+
+
+def test_search_item_summaries_builds_headers_and_params() -> None:
+    session = FakeSession([FakeResponse(json_data={"itemSummaries": []})])
+    client = EbayBrowseClient(
+        token_provider=FakeTokenProvider(),
+        session=session,
+        sleeper=lambda _: None,
+    )
+
+    client.search_item_summaries(
+        "pokemon",
+        filters={
+            "min_price": 10,
+            "max_price": 20,
+            "buying_options": "FIXED_PRICE",
+            "condition": "NEW",
+            "item_location": "GB",
+        },
+        limit=50,
+        offset=100,
+        sort_order="price",
+    )
+
+    call = session.calls[0]
+    assert call["url"].endswith("/item_summary/search")
+    assert call["headers"] == {
+        "Authorization": "Bearer test-token",
+        "X-EBAY-C-MARKETPLACE-ID": "EBAY-GB",
+        "X-EBAY-C-CURRENCY": "GBP",
+        "Content-Language": "en-GB",
+        "Accept-Language": "en-GB",
+        "Content-Type": "application/json",
+    }
+    assert call["params"] == {
+        "q": "pokemon",
+        "limit": 50,
+        "offset": 100,
+        "sort": "price",
+        "filter": (
+            "itemLocationCountry:GB,buyingOptions:{FIXED_PRICE},"
+            "conditions:{NEW},priceCurrency:GBP,price:[10..20]"
+        ),
+    }
+
+
+def test_search_item_summaries_applies_marketplace_override() -> None:
+    session = FakeSession([FakeResponse(json_data={"itemSummaries": []})])
+    client = EbayBrowseClient(
+        token_provider=FakeTokenProvider(),
+        session=session,
+        sleeper=lambda _: None,
+    )
+
+    client.search_item_summaries(
+        "iphone",
+        filters={"item_location": "any", "min_price": 100},
+        marketplace="EBAY_US",
+    )
+
+    call = session.calls[0]
+    assert client.marketplace == "EBAY_US"
+    assert client.country_code == "US"
+    assert client.currency == "USD"
+    assert call["headers"]["X-EBAY-C-MARKETPLACE-ID"] == "EBAY-US"
+    assert call["headers"]["X-EBAY-C-CURRENCY"] == "USD"
+    assert call["headers"]["Content-Language"] == "en-US"
+    assert call["params"]["filter"] == "priceCurrency:USD,price:[100..]"
+
+
+def test_search_item_summaries_retries_429_with_retry_after() -> None:
+    sleep_calls: list[float] = []
+    session = FakeSession(
+        [
+            FakeResponse(
+                json_data={"error": "rate limited"},
+                status_code=429,
+                headers={"Retry-After": "2"},
+            ),
+            FakeResponse(json_data={"itemSummaries": []}),
+        ]
+    )
+    client = EbayBrowseClient(
+        token_provider=FakeTokenProvider(),
+        session=session,
+        sleeper=sleep_calls.append,
+        rate_limit_retries=1,
+    )
+
+    assert client.search_item_summaries("pokemon") == {"itemSummaries": []}
+
+    assert sleep_calls == [2]
+    assert len(session.calls) == 2
+
+
+def test_search_items_stops_when_page_is_short() -> None:
+    sleep_calls: list[float] = []
+    session = FakeSession(
+        [
+            FakeResponse(
+                json_data={"itemSummaries": [fake_item("one"), fake_item("two")]}
+            )
+        ]
+    )
+    client = EbayBrowseClient(
+        token_provider=FakeTokenProvider(),
+        session=session,
+        sleeper=sleep_calls.append,
+    )
+
+    items = client.search_items("pokemon", max_pages=None)
+
+    assert [item["ebay_id"] for item in items] == ["one", "two"]
+    assert sleep_calls == [1.0]
+    assert len(session.calls) == 1
+    assert session.calls[0]["params"]["offset"] == 0
+
+
+def test_search_items_dedupes_across_pages() -> None:
+    first_page = [fake_item(str(index)) for index in range(200)]
+    second_page = [fake_item("199"), fake_item("200")]
+    session = FakeSession(
+        [
+            FakeResponse(json_data={"itemSummaries": first_page}),
+            FakeResponse(json_data={"itemSummaries": second_page}),
+        ]
+    )
+    client = EbayBrowseClient(
+        token_provider=FakeTokenProvider(),
+        session=session,
+        sleeper=lambda _: None,
+    )
+
+    items = client.search_items("pokemon", max_pages=None)
+    item_ids = [item["ebay_id"] for item in items]
+
+    assert len(items) == 201
+    assert item_ids.count("199") == 1
+    assert item_ids[-1] == "200"
+    assert [call["params"]["offset"] for call in session.calls] == [0, 200]

--- a/ebay_client/browse/client.py
+++ b/ebay_client/browse/client.py
@@ -1,14 +1,20 @@
 import logging
 import time
+from collections.abc import Callable, Mapping
+from typing import Any
 
-import requests
+import requests  # type: ignore[import-untyped]
 
-from ebay_client.browse.dto import SearchFilters, SearchRequest
 from ebay_client.browse.filters import SearchFilterBuilder
+from ebay_client.browse.headers import build_browse_headers
+from ebay_client.browse.pagination import collect_search_items
 from ebay_client.browse.parsers import parse_item_summary_response
-from ebay_client.browse.responses import dedupe_items
+from ebay_client.browse.search_requests import (
+    build_search_params,
+    create_search_request,
+)
+from ebay_client.browse.transport import fetch_json_with_retry
 from ebay_client.marketplaces import get_marketplace
-
 
 logger = logging.getLogger(__name__)
 
@@ -19,20 +25,37 @@ class EbayBrowseClient:
     token_url = "https://api.ebay.com/identity/v1/oauth2/token"
     base_url = "https://api.ebay.com/buy/browse/v1"
 
-    def __init__(self, token_provider, marketplace="EBAY_GB", session=None):
+    def __init__(
+        self,
+        token_provider: Any,
+        marketplace: str = "EBAY_GB",
+        session: requests.Session | None = None,
+        sleeper: Callable[[float], None] = time.sleep,
+        rate_limit_retries: int = 3,
+    ) -> None:
         self.token_provider = token_provider
         self.marketplace = marketplace
         self.session = session or requests.Session()
+        self.sleeper = sleeper
+        self.rate_limit_retries = rate_limit_retries
+
+        self._configure_session(self.session)
+        self._set_marketplace_config(marketplace)
+
+    @staticmethod
+    def _configure_session(session: requests.Session) -> None:
+        """Apply connection pooling to real requests sessions."""
+        if not hasattr(session, "mount"):
+            return
 
         adapter = requests.adapters.HTTPAdapter(
             pool_connections=30,
             pool_maxsize=200,
             max_retries=3,
         )
-        self.session.mount("https://", adapter)
-        self._set_marketplace_config(marketplace)
+        session.mount("https://", adapter)
 
-    def _set_marketplace_config(self, marketplace):
+    def _set_marketplace_config(self, marketplace: str) -> None:
         self.marketplace = marketplace
         self.marketplace_config = get_marketplace(marketplace)
         self.country_code = self.marketplace_config.location
@@ -42,102 +65,74 @@ class EbayBrowseClient:
         self,
         keywords,
         filters=None,
-        limit=200,
-        offset=0,
-        sort_order=None,
-        marketplace=None,
-    ):
+        limit: int = 200,
+        offset: int = 0,
+        sort_order: str | None = None,
+        marketplace: str | None = None,
+    ) -> dict[str, Any]:
         if marketplace:
             self._set_marketplace_config(marketplace)
 
-        request = SearchRequest(
+        request = create_search_request(
             keywords=keywords,
-            filters=SearchFilters.from_mapping(filters),
+            filters=filters,
             limit=limit,
             offset=offset,
             sort_order=sort_order,
         )
-        token = self.token_provider.get_token()
-        marketplace_header = self.marketplace.replace("_", "-")
-
-        headers = {
-            "Authorization": f"Bearer {token}",
-            "X-EBAY-C-MARKETPLACE-ID": marketplace_header,
-            "X-EBAY-C-CURRENCY": self.currency,
-            "Content-Language": self.marketplace_config.language,
-            "Accept-Language": self.marketplace_config.language,
-            "Content-Type": "application/json",
-        }
-        params = {
-            "q": request.keywords,
-            "limit": request.limit,
-            "offset": request.offset,
-        }
-
-        if request.sort_order:
-            params["sort"] = request.sort_order
-
-        filter_value = self.build_filter(request.filters)
-        if filter_value:
-            params["filter"] = filter_value
-
-        response = self.session.get(
-            f"{self.base_url}/item_summary/search",
+        headers = self._build_headers()
+        params = build_search_params(request, self.build_filter(request.filters))
+        return fetch_json_with_retry(
+            session=self.session,
+            url=self._search_url(),
             headers=headers,
             params=params,
+            max_retries=self.rate_limit_retries,
+            sleeper=self.sleeper,
         )
 
-        if response.status_code == 429:
-            sleep_time = int(response.headers.get("Retry-After", 60))
-            time.sleep(sleep_time)
-            return self.search_item_summaries(
-                keywords,
-                filters,
-                limit,
-                offset,
-                sort_order,
-                marketplace,
-            )
+    def _build_headers(self) -> dict[str, str]:
+        """Build authenticated headers for the current marketplace."""
+        return build_browse_headers(
+            token=self.token_provider.get_token(),
+            marketplace=self.marketplace,
+            currency=self.currency,
+            language=self.marketplace_config.language,
+        )
 
-        response.raise_for_status()
-        return response.json()
+    def _search_url(self) -> str:
+        """Return the Browse item summary search URL."""
+        return f"{self.base_url}/item_summary/search"
 
     def search_items(
         self,
         keywords,
         filters=None,
-        sort_order=None,
-        max_pages=1,
-        marketplace=None,
-    ):
+        sort_order: str | None = None,
+        max_pages: int | None = 1,
+        marketplace: str | None = None,
+    ) -> list[dict[str, Any]]:
         if marketplace:
             self._set_marketplace_config(marketplace)
 
-        returned_items = []
-        pages_searched = 0
-        offset = 0
-
-        while max_pages is None or pages_searched < max_pages:
-            time.sleep(1)
-            raw_response = self.search_item_summaries(
+        return collect_search_items(
+            fetch_page=lambda offset, limit: self.search_item_summaries(
                 keywords=keywords,
                 filters=filters,
-                limit=200,
+                limit=limit,
                 offset=offset,
                 sort_order=sort_order,
-            )
-            parsed_items = self.parse_item_summary_response(raw_response)
-            returned_items.extend(parsed_items)
+            ),
+            parse_page=self.parse_item_summary_response,
+            max_pages=max_pages,
+            sleeper=self.sleeper,
+        )
 
-            offset += len(parsed_items)
-            pages_searched += 1
-            if len(parsed_items) < 200:
-                break
-
-        return dedupe_items(returned_items)
-
-    def build_filter(self, filters):
+    def build_filter(self, filters) -> str:
         return SearchFilterBuilder(self.currency).build(filters)
 
-    def parse_item_summary_response(self, response):
+    def parse_item_summary_response(
+        self,
+        response: Mapping[str, Any],
+    ) -> list[dict[str, Any]]:
         return parse_item_summary_response(response, default_currency=self.currency)

--- a/ebay_client/browse/headers.py
+++ b/ebay_client/browse/headers.py
@@ -1,0 +1,20 @@
+"""Header helpers for eBay Browse API requests."""
+
+
+def build_browse_headers(
+    *,
+    token: str,
+    marketplace: str,
+    currency: str,
+    language: str,
+) -> dict[str, str]:
+    """Build headers shared by Browse API calls."""
+    marketplace_header = marketplace.replace("_", "-")
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-EBAY-C-MARKETPLACE-ID": marketplace_header,
+        "X-EBAY-C-CURRENCY": currency,
+        "Content-Language": language,
+        "Accept-Language": language,
+        "Content-Type": "application/json",
+    }

--- a/ebay_client/browse/pagination.py
+++ b/ebay_client/browse/pagination.py
@@ -1,0 +1,36 @@
+"""Pagination helpers for eBay Browse search results."""
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+from ebay_client.browse.responses import dedupe_items
+
+ParsedItem = dict[str, Any]
+RawResponse = Mapping[str, Any]
+
+
+def collect_search_items(
+    *,
+    fetch_page: Callable[[int, int], RawResponse],
+    parse_page: Callable[[RawResponse], Sequence[ParsedItem]],
+    max_pages: int | None,
+    sleeper: Callable[[float], None],
+    page_delay_seconds: float = 1.0,
+    page_size: int = 200,
+) -> list[ParsedItem]:
+    """Fetch, parse, and dedupe paginated Browse search results."""
+    returned_items: list[ParsedItem] = []
+    pages_searched = 0
+    offset = 0
+
+    while max_pages is None or pages_searched < max_pages:
+        sleeper(page_delay_seconds)
+        parsed_items = list(parse_page(fetch_page(offset, page_size)))
+        returned_items.extend(parsed_items)
+
+        offset += len(parsed_items)
+        pages_searched += 1
+        if len(parsed_items) < page_size:
+            break
+
+    return dedupe_items(returned_items)

--- a/ebay_client/browse/search_requests.py
+++ b/ebay_client/browse/search_requests.py
@@ -1,0 +1,49 @@
+"""Search request construction helpers for eBay Browse API."""
+
+from collections.abc import Mapping
+from typing import Any
+
+from ebay_client.browse.dto import SearchFilters, SearchRequest
+
+
+def create_search_request(
+    *,
+    keywords: str,
+    filters: Mapping[str, Any] | SearchFilters | None,
+    limit: int,
+    offset: int,
+    sort_order: str | None,
+) -> SearchRequest:
+    """Create a normalized search request DTO from public method arguments."""
+    search_filters = (
+        filters
+        if isinstance(filters, SearchFilters)
+        else SearchFilters.from_mapping(filters)
+    )
+    return SearchRequest(
+        keywords=keywords,
+        filters=search_filters,
+        limit=limit,
+        offset=offset,
+        sort_order=sort_order,
+    )
+
+
+def build_search_params(
+    request: SearchRequest,
+    filter_value: str | None,
+) -> dict[str, str | int]:
+    """Build query params for the item summary search endpoint."""
+    params: dict[str, str | int] = {
+        "q": request.keywords,
+        "limit": request.limit,
+        "offset": request.offset,
+    }
+
+    if request.sort_order:
+        params["sort"] = request.sort_order
+
+    if filter_value:
+        params["filter"] = filter_value
+
+    return params

--- a/ebay_client/browse/transport.py
+++ b/ebay_client/browse/transport.py
@@ -1,0 +1,55 @@
+"""HTTP transport helpers for eBay Browse API calls."""
+
+import logging
+import time
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import requests  # type: ignore[import-untyped]
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_json_with_retry(
+    *,
+    session: requests.Session,
+    url: str,
+    headers: Mapping[str, str],
+    params: Mapping[str, str | int],
+    max_retries: int,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    """Fetch JSON with bounded Retry-After handling for HTTP 429 responses."""
+    response: requests.Response | None = None
+
+    for attempt in range(max_retries + 1):
+        response = session.get(url, headers=dict(headers), params=dict(params))
+        if response.status_code != 429:
+            response.raise_for_status()
+            return response.json()
+
+        if attempt == max_retries:
+            break
+
+        sleep_time = parse_retry_after(response.headers.get("Retry-After"))
+        logger.warning(
+            "eBay Browse rate limited; retrying after %s seconds", sleep_time
+        )
+        sleeper(sleep_time)
+
+    if response is None:
+        raise RuntimeError("Browse request did not return a response")
+
+    response.raise_for_status()
+    return response.json()
+
+
+def parse_retry_after(value: str | None, default: int = 60) -> int:
+    """Return a non-negative Retry-After value in seconds."""
+    if value is None:
+        return default
+
+    try:
+        return max(0, int(value))
+    except ValueError:
+        return default


### PR DESCRIPTION
## Summary
- Split Browse search request construction, headers, retry transport, and pagination/dedupe into focused helper modules.
- Kept `EbayBrowseClient` public methods as orchestration wrappers preserving marketplace, currency, country code, filter, and parser behavior.
- Added offline fake-session/token-provider tests for headers/params, marketplace override, 429 retry, pagination stopping, and dedupe.

Closes #13

## Validation
- `pytest app/tests/test_ebay_browse_client.py` passed.
- `pytest` was run and fails during collection on pre-existing app-level issues: missing `Query`, `archive_items`, `cancel_subscription_logic`, and required `ENCRYPTION_KEY`.
- `black .` was run; broad pre-existing formatting churn was reverted to keep this PR scoped, and touched files were formatted with Black.
- `mypy .` was run and fails on pre-existing missing stubs/app typing issues; scoped check `mypy --follow-imports=skip ebay_client/browse/client.py ebay_client/browse/headers.py ebay_client/browse/pagination.py ebay_client/browse/search_requests.py ebay_client/browse/transport.py app/tests/test_ebay_browse_client.py` passed.
