### PR TITLE
[codex] Refactor browse item summary parser

### DIFF
--- a/app/tests/test_ebay_browse_parsers.py
+++ b/app/tests/test_ebay_browse_parsers.py
@@ -1,0 +1,150 @@
+import json
+from datetime import datetime, timezone
+
+from ebay_client.browse.parsers import parse_item_summary_response
+
+
+def test_parse_fixed_price_item_summary_response():
+    response = {
+        "itemSummaries": [
+            {
+                "itemId": "v1|123|0",
+                "legacyItemId": "123",
+                "title": "Vintage Camera",
+                "price": {"value": "12.50", "currency": "GBP"},
+                "buyingOptions": ["FIXED_PRICE"],
+                "itemWebUrl": "https://www.ebay.co.uk/itm/123",
+                "image": {"imageUrl": "https://i.ebayimg.com/images/123.jpg"},
+                "seller": {"username": "camera-shop", "feedbackPercentage": "99.8"},
+                "condition": "Used",
+                "itemLocation": {"country": "GB", "postalCode": "SW1A"},
+                "itemCreationDate": "2026-04-01T10:11:12.000Z",
+                "itemEndDate": "2026-04-08T10:11:12.000Z",
+                "listingMarketplaceId": "EBAY_GB",
+            }
+        ]
+    }
+
+    item = parse_item_summary_response(response)[0]
+
+    assert item["ebay_id"] == "v1|123|0"
+    assert item["legacy_id"] == "123"
+    assert item["title"] == "Vintage Camera"
+    assert item["price"] == 12.5
+    assert item["currency"] == "GBP"
+    assert item["current_bid"] == 0
+    assert item["current_bid_currency"] == "GBP"
+    assert item["auction_details"] is None
+    assert item["buying_options"] == json.dumps(["FIXED_PRICE"])
+    assert item["start_time"] == datetime(2026, 4, 1, 10, 11, 12, tzinfo=timezone.utc)
+    assert item["end_time"] == datetime(2026, 4, 8, 10, 11, 12, tzinfo=timezone.utc)
+
+
+def test_parse_auction_item_summary_response():
+    response = {
+        "itemSummaries": [
+            {
+                "itemId": "v1|auction|0",
+                "title": "Rare Record",
+                "price": {"value": "20.00", "currency": "GBP"},
+                "buyingOptions": ["AUCTION"],
+                "bidCount": 7,
+                "currentBidPrice": {"value": "44.25", "currency": "USD"},
+                "itemEndDate": "2026-05-01T17:30:00.000Z",
+                "listingMarketplaceId": "EBAY_US",
+            }
+        ]
+    }
+
+    item = parse_item_summary_response(response)[0]
+    auction_details = json.loads(item["auction_details"])
+
+    assert item["price"] == 20.0
+    assert item["current_bid"] == 44.25
+    assert item["current_bid_currency"] == "USD"
+    assert auction_details == {
+        "bid_count": 7,
+        "current_bid": {"value": 44.25, "currency": "USD"},
+        "end_time": "2026-05-01T17:30:00.000Z",
+        "marketplace_id": "EBAY_US",
+    }
+
+
+def test_parse_item_summary_response_with_missing_optional_fields():
+    response = {
+        "itemSummaries": [
+            {
+                "itemId": "v1|minimal|0",
+                "price": {"value": "3.00", "currency": "GBP"},
+            }
+        ]
+    }
+
+    item = parse_item_summary_response(response)[0]
+
+    assert item["title"] == "No Title"
+    assert item["image_url"] is None
+    assert item["seller"] is None
+    assert item["seller_rating"] is None
+    assert item["condition"] is None
+    assert item["location"] == {"country": None, "postal_code": None}
+    assert item["start_time"] is None
+    assert item["end_time"] is None
+    assert item["buying_options"] == json.dumps([])
+    assert item["auction_details"] is None
+    assert json.loads(item["categories"]) == {"ids": [], "names": []}
+    assert json.loads(item["images"]) == {"main": None, "thumbnails": []}
+
+
+def test_parse_item_summary_response_with_categories_and_images():
+    response = {
+        "itemSummaries": [
+            {
+                "itemId": "v1|media|0",
+                "price": {"value": "9.99", "currency": "GBP"},
+                "categories": [
+                    {"categoryId": "625", "categoryName": "Cameras"},
+                    {"categoryId": "31388", "categoryName": "Film Cameras"},
+                ],
+                "image": {"imageUrl": "https://i.ebayimg.com/images/main.jpg"},
+                "thumbnailImages": [
+                    {"imageUrl": "https://i.ebayimg.com/images/thumb-1.jpg"},
+                    {"imageUrl": "https://i.ebayimg.com/images/thumb-2.jpg"},
+                ],
+            }
+        ]
+    }
+
+    item = parse_item_summary_response(response)[0]
+
+    assert json.loads(item["categories"]) == {
+        "ids": ["625", "31388"],
+        "names": ["Cameras", "Film Cameras"],
+    }
+    assert json.loads(item["images"]) == {
+        "main": "https://i.ebayimg.com/images/main.jpg",
+        "thumbnails": [
+            "https://i.ebayimg.com/images/thumb-1.jpg",
+            "https://i.ebayimg.com/images/thumb-2.jpg",
+        ],
+    }
+
+
+def test_parse_item_summary_response_uses_default_currency():
+    response = {
+        "itemSummaries": [
+            {
+                "itemId": "v1|default-currency|0",
+                "price": {"value": "7.50"},
+                "buyingOptions": ["AUCTION"],
+                "currentBidPrice": {"value": "8.25"},
+            }
+        ]
+    }
+
+    item = parse_item_summary_response(response, default_currency="EUR")[0]
+    auction_details = json.loads(item["auction_details"])
+
+    assert item["currency"] == "EUR"
+    assert item["current_bid_currency"] == "EUR"
+    assert auction_details["current_bid"] == {"value": 8.25, "currency": "EUR"}

--- a/ebay_client/browse/parsers.py
+++ b/ebay_client/browse/parsers.py
@@ -1,88 +1,146 @@
 import json
+from typing import Any
 
 from ebay_client.time import parse_ebay_datetime
 
+ItemSummary = dict[str, Any]
+ParsedItem = dict[str, Any]
+Money = dict[str, Any]
 
-def parse_item_summary_response(response, default_currency="GBP"):
-    items = []
-    for item_data in response.get("itemSummaries", []):
-        price_info = item_data.get("price", {})
-        base_price = {
-            "value": float(price_info.get("value", 0)),
-            "currency": price_info.get("currency", default_currency),
-        }
 
-        raw_buying_options = item_data.get("buyingOptions", [])
-        is_auction = "AUCTION" in raw_buying_options
-        auction_data = (
-            {
-                "bid_count": item_data.get("bidCount", 0),
-                "current_bid": {
-                    "value": float(item_data.get("currentBidPrice", {}).get("value", 0)),
-                    "currency": item_data.get("currentBidPrice", {}).get(
-                        "currency", default_currency
-                    ),
-                },
-                "end_time": item_data.get("itemEndDate"),
-                "marketplace_id": item_data.get("listingMarketplaceId"),
-            }
-            if is_auction
-            else None
-        )
+def parse_item_summary_response(
+    response: dict[str, Any], default_currency: str = "GBP"
+) -> list[ParsedItem]:
+    """Parse an eBay Browse item summary response into application item dicts."""
+    return [
+        _map_item_summary(item_data, default_currency)
+        for item_data in response.get("itemSummaries", [])
+    ]
 
-        items.append(
-            {
-                "ebay_id": item_data.get("itemId"),
-                "legacy_id": item_data.get("legacyItemId"),
-                "title": item_data.get("title", "No Title"),
-                "price": base_price["value"],
-                "current_bid": (
-                    auction_data["current_bid"]["value"]
-                    if auction_data and "current_bid" in auction_data
-                    else 0
-                ),
-                "current_bid_currency": (
-                    auction_data["current_bid"]["currency"]
-                    if auction_data and "current_bid" in auction_data
-                    else base_price.get("currency", default_currency)
-                ),
-                "currency": base_price["currency"],
-                "url": item_data.get("itemWebUrl"),
-                "image_url": item_data.get("image", {}).get("imageUrl"),
-                "seller": item_data.get("seller", {}).get("username"),
-                "seller_rating": item_data.get("seller", {}).get("feedbackPercentage"),
-                "condition": item_data.get("condition"),
-                "location": {
-                    "country": item_data.get("itemLocation", {}).get("country"),
-                    "postal_code": item_data.get("itemLocation", {}).get("postalCode"),
-                },
-                "start_time": parse_ebay_datetime(item_data.get("itemCreationDate")),
-                "end_time": parse_ebay_datetime(item_data.get("itemEndDate")),
-                "buying_options": json.dumps(raw_buying_options),
-                "auction_details": json.dumps(auction_data) if auction_data else None,
-                "categories": json.dumps(
-                    {
-                        "ids": [
-                            category["categoryId"]
-                            for category in item_data.get("categories", [])
-                        ],
-                        "names": [
-                            category["categoryName"]
-                            for category in item_data.get("categories", [])
-                        ],
-                    }
-                ),
-                "marketplace": item_data.get("listingMarketplaceId"),
-                "images": json.dumps(
-                    {
-                        "main": item_data.get("image", {}).get("imageUrl"),
-                        "thumbnails": [
-                            image.get("imageUrl")
-                            for image in item_data.get("thumbnailImages", [])
-                        ],
-                    }
-                ),
-            }
-        )
 
-    return items
+def _map_item_summary(item_data: ItemSummary, default_currency: str) -> ParsedItem:
+    """Map one eBay item summary to the app's expected flattened item shape."""
+    base_price = _parse_money(item_data.get("price"), default_currency)
+    raw_buying_options = item_data.get("buyingOptions", [])
+    auction_details = _parse_auction_details(
+        item_data, raw_buying_options, default_currency
+    )
+
+    return {
+        "ebay_id": item_data.get("itemId"),
+        "legacy_id": item_data.get("legacyItemId"),
+        "title": item_data.get("title", "No Title"),
+        "price": base_price["value"],
+        "current_bid": _current_bid_value(auction_details),
+        "current_bid_currency": _current_bid_currency(
+            auction_details, base_price, default_currency
+        ),
+        "currency": base_price["currency"],
+        "url": item_data.get("itemWebUrl"),
+        "image_url": _image_url(item_data),
+        **_seller_details(item_data),
+        "condition": item_data.get("condition"),
+        "location": _location(item_data),
+        **_datetime_fields(item_data),
+        "buying_options": json.dumps(raw_buying_options),
+        "auction_details": json.dumps(auction_details) if auction_details else None,
+        "categories": json.dumps(_categories(item_data)),
+        "marketplace": item_data.get("listingMarketplaceId"),
+        "images": json.dumps(_images(item_data)),
+    }
+
+
+def _parse_money(price_info: dict[str, Any] | None, default_currency: str) -> Money:
+    """Parse eBay money fields while preserving the default currency fallback."""
+    raw_price = price_info or {}
+
+    return {
+        "value": float(raw_price.get("value", 0)),
+        "currency": raw_price.get("currency", default_currency),
+    }
+
+
+def _parse_auction_details(
+    item_data: ItemSummary, buying_options: list[str], default_currency: str
+) -> dict[str, Any] | None:
+    """Build auction metadata for auction listings only."""
+    if "AUCTION" not in buying_options:
+        return None
+
+    return {
+        "bid_count": item_data.get("bidCount", 0),
+        "current_bid": _parse_money(item_data.get("currentBidPrice"), default_currency),
+        "end_time": item_data.get("itemEndDate"),
+        "marketplace_id": item_data.get("listingMarketplaceId"),
+    }
+
+
+def _current_bid_value(auction_details: dict[str, Any] | None) -> float | int:
+    """Return the numeric current bid used by the flattened item shape."""
+    if auction_details and "current_bid" in auction_details:
+        return auction_details["current_bid"]["value"]
+
+    return 0
+
+
+def _current_bid_currency(
+    auction_details: dict[str, Any] | None, base_price: Money, default_currency: str
+) -> Any:
+    """Return the current bid currency, falling back to the listing currency."""
+    if auction_details and "current_bid" in auction_details:
+        return auction_details["current_bid"]["currency"]
+
+    return base_price.get("currency", default_currency)
+
+
+def _seller_details(item_data: ItemSummary) -> dict[str, Any]:
+    """Extract seller identity and rating fields."""
+    seller = item_data.get("seller", {})
+
+    return {
+        "seller": seller.get("username"),
+        "seller_rating": seller.get("feedbackPercentage"),
+    }
+
+
+def _location(item_data: ItemSummary) -> dict[str, Any]:
+    """Extract item location details."""
+    item_location = item_data.get("itemLocation", {})
+
+    return {
+        "country": item_location.get("country"),
+        "postal_code": item_location.get("postalCode"),
+    }
+
+
+def _datetime_fields(item_data: ItemSummary) -> dict[str, Any]:
+    """Parse date fields into datetime objects."""
+    return {
+        "start_time": parse_ebay_datetime(item_data.get("itemCreationDate")),
+        "end_time": parse_ebay_datetime(item_data.get("itemEndDate")),
+    }
+
+
+def _categories(item_data: ItemSummary) -> dict[str, list[str]]:
+    """Extract category identifiers and names."""
+    categories = item_data.get("categories", [])
+
+    return {
+        "ids": [category["categoryId"] for category in categories],
+        "names": [category["categoryName"] for category in categories],
+    }
+
+
+def _image_url(item_data: ItemSummary) -> str | None:
+    """Return the primary listing image URL."""
+    return item_data.get("image", {}).get("imageUrl")
+
+
+def _images(item_data: ItemSummary) -> dict[str, Any]:
+    """Extract the main image and thumbnail image URLs."""
+    return {
+        "main": _image_url(item_data),
+        "thumbnails": [
+            image.get("imageUrl") for image in item_data.get("thumbnailImages", [])
+        ],
+    }


### PR DESCRIPTION
## Summary
- Split `parse_item_summary_response` into focused helpers for money parsing, auction metadata, seller/location/category/image extraction, datetime fields, and final item mapping.
- Preserved the public `parse_item_summary_response(response, default_currency="GBP")` entry point and existing flattened item dict shape.
- Added offline parser tests covering fixed-price listings, auctions, missing optional fields, categories/images, and default currency fallback.

## Issue
No GitHub issue number was provided in the orchestrator task, so this PR does not include an auto-closing issue link.

## Validation
- `pytest app/tests/test_ebay_browse_parsers.py` passed.
- `black .` ran; it reformatted many unrelated legacy files, which were restored to keep this PR scoped. Touched files pass `black --check ebay_client/browse/parsers.py app/tests/test_ebay_browse_parsers.py`.
- `mypy --follow-imports=skip ebay_client/browse/parsers.py app/tests/test_ebay_browse_parsers.py` passed.
- `pytest` was run and fails during collection on existing unrelated issues: missing `Query`, `archive_items`, `cancel_subscription_logic`, and required `ENCRYPTION_KEY` for `test_telegram_notification.py`.
- `mypy .` was run and fails on existing unrelated missing stubs/model attributes across the app.
