### PR TITLE
[codex] Refactor eBay auth config internals

### DIFF
--- a/app/tests/test_ebay_auth_config.py
+++ b/app/tests/test_ebay_auth_config.py
@@ -1,0 +1,212 @@
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from ebay_client.auth import (
+    CredentialRotator,
+    EbayTokenProvider,
+    InMemoryTokenStore,
+    JsonTokenStore,
+)
+from ebay_client.auth.credentials import EbayCredential
+from ebay_client.config.credentials import load_ebay_credentials
+
+TOKEN_URL = "https://api.ebay.com/identity/v1/oauth2/token"
+
+
+class FakeOAuthClient:
+    """Offline OAuth client test double for token provider tests."""
+
+    def __init__(
+        self,
+        token: str = "fresh-token",
+        ttl: timedelta = timedelta(hours=2),
+    ) -> None:
+        self.token = token
+        self.ttl = ttl
+        self.calls: list[str] = []
+
+    def fetch_client_credentials_token(self, credential: Any) -> tuple[str, timedelta]:
+        self.calls.append(credential.client_id)
+        return self.token, self.ttl
+
+
+def test_load_ebay_credentials_from_json_env() -> None:
+    payload = json.dumps(
+        [
+            {
+                "clientId": "json-client",
+                "clientSecret": "json-secret",
+                "token": "cached-token",
+                "token_expiry": "2026-01-01T00:00:00+00:00",
+            }
+        ]
+    )
+
+    credentials = load_ebay_credentials({"EBAY_CREDENTIALS_JSON": payload})
+
+    assert credentials == [
+        {
+            "client_id": "json-client",
+            "client_secret": "json-secret",
+            "token": "cached-token",
+            "token_expiry": "2026-01-01T00:00:00+00:00",
+        }
+    ]
+
+
+def test_load_ebay_credentials_from_single_env_fallback() -> None:
+    credentials = load_ebay_credentials(
+        {
+            "EBAY_CLIENT_ID": "single-client",
+            "EBAY_CLIENT_SECRET": "single-secret",
+            "EBAY_ACCESS_TOKEN": "single-token",
+        }
+    )
+
+    assert credentials == [
+        {
+            "client_id": "single-client",
+            "client_secret": "single-secret",
+            "token": "single-token",
+            "token_expiry": None,
+        }
+    ]
+
+
+def test_load_ebay_credentials_from_empty_env() -> None:
+    assert load_ebay_credentials({}) == []
+
+
+def test_get_token_refreshes_expired_credential() -> None:
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    ttl = timedelta(minutes=30)
+    credentials = [
+        {
+            "client_id": "refresh-client",
+            "client_secret": "refresh-secret",
+            "token": None,
+            "token_expiry": None,
+        }
+    ]
+    oauth_client = FakeOAuthClient(ttl=ttl)
+    provider = EbayTokenProvider(
+        credentials=credentials,
+        token_url=TOKEN_URL,
+        oauth_client=oauth_client,
+        token_store=InMemoryTokenStore(),
+        clock=lambda: now,
+    )
+
+    token = provider.get_token()
+
+    assert token == "fresh-token"
+    assert oauth_client.calls == ["refresh-client"]
+    assert credentials[0]["token"] == "fresh-token"
+    assert credentials[0]["token_expiry"] == now + ttl
+
+
+def test_get_token_uses_cached_token() -> None:
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    credentials = [
+        {
+            "client_id": "cached-client",
+            "client_secret": "cached-secret",
+            "token": "cached-token",
+            "token_expiry": now + timedelta(hours=1),
+        }
+    ]
+    oauth_client = FakeOAuthClient()
+    provider = EbayTokenProvider(
+        credentials=credentials,
+        token_url=TOKEN_URL,
+        oauth_client=oauth_client,
+        token_store=InMemoryTokenStore(),
+        clock=lambda: now,
+    )
+
+    token = provider.get_token()
+
+    assert token == "cached-token"
+    assert oauth_client.calls == []
+
+
+def test_provider_synchronizes_rotator_index_before_and_after_rotation() -> None:
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    credentials = [
+        {
+            "client_id": "first-client",
+            "client_secret": "first-secret",
+            "token": "first-token",
+            "token_expiry": now + timedelta(hours=1),
+        },
+        {
+            "client_id": "second-client",
+            "client_secret": "second-secret",
+            "token": "second-token",
+            "token_expiry": now + timedelta(hours=1),
+        },
+    ]
+    rotator = CredentialRotator([], current_index=0)
+    provider = EbayTokenProvider(
+        credentials=credentials,
+        token_url=TOKEN_URL,
+        rotator=rotator,
+        oauth_client=FakeOAuthClient(),
+        token_store=InMemoryTokenStore(),
+        clock=lambda: now,
+    )
+    provider.current_cred_index = 1
+
+    token = provider.get_token()
+
+    assert token == "second-token"
+    assert rotator.credentials == credentials
+    assert provider.current_cred_index == 0
+
+
+def test_json_token_store_saves_and_loads_token_data(tmp_path) -> None:
+    token_expiry = datetime(2026, 1, 1, 12, 30, tzinfo=timezone.utc)
+    token_store = JsonTokenStore(tmp_path / "tokens.json")
+    credential = EbayCredential(
+        client_id="stored-client",
+        client_secret="stored-secret",
+        token="stored-token",
+        token_expiry=token_expiry,
+    )
+
+    token_store.save(credential)
+    loaded = token_store.load(
+        {
+            "client_id": "stored-client",
+            "client_secret": "stored-secret",
+        }
+    )
+
+    assert loaded.token == "stored-token"
+    assert loaded.token_expiry == token_expiry
+
+
+def test_json_token_store_parses_datetime_values(tmp_path) -> None:
+    token_file = tmp_path / "tokens.json"
+    token_file.write_text(
+        json.dumps(
+            {
+                "datetime-client": {
+                    "token": "datetime-token",
+                    "token_expiry": "2026-01-01T12:30:00Z",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = JsonTokenStore(token_file).load(
+        {
+            "client_id": "datetime-client",
+            "client_secret": "datetime-secret",
+        }
+    )
+
+    assert loaded.token == "datetime-token"
+    assert loaded.token_expiry == datetime(2026, 1, 1, 12, 30, tzinfo=timezone.utc)

--- a/ebay_client/auth/provider.py
+++ b/ebay_client/auth/provider.py
@@ -1,11 +1,14 @@
 from datetime import datetime, timezone
 import os
 from pathlib import Path
+from typing import Any, Callable, Optional
 
 from .expiry import TokenExpiryPolicy
 from .oauth import EbayOAuthClient
 from .rotation import CredentialRotator
-from .token_store import JsonTokenStore
+from .token_store import JsonTokenStore, TokenStore
+
+Clock = Callable[[], datetime]
 
 
 class EbayTokenProvider:
@@ -13,54 +16,109 @@ class EbayTokenProvider:
 
     def __init__(
         self,
-        credentials,
-        token_url,
-        session=None,
-        rotator=None,
-        oauth_client=None,
-        token_store=None,
-        expiry_policy=None,
-        clock=None,
-    ):
+        credentials: Any,
+        token_url: str,
+        session: Any = None,
+        rotator: Optional[CredentialRotator] = None,
+        oauth_client: Any = None,
+        token_store: Optional[TokenStore] = None,
+        expiry_policy: Optional[TokenExpiryPolicy] = None,
+        clock: Optional[Clock] = None,
+    ) -> None:
         self.credentials = credentials or []
         self.current_cred_index = 0
         self.token_url = token_url
-        self.clock = clock or (lambda: datetime.now(timezone.utc))
-        self.token_store = token_store or JsonTokenStore(_default_token_store_path())
-        self.expiry_policy = expiry_policy or TokenExpiryPolicy(clock=self.clock)
-        self.oauth_client = oauth_client or EbayOAuthClient(token_url, session=session)
-        self.rotator = rotator or CredentialRotator(self.credentials)
+        self.clock = _resolve_clock(clock)
+        self.token_store = _resolve_token_store(token_store)
+        self.expiry_policy = _resolve_expiry_policy(expiry_policy, self.clock)
+        self.oauth_client = _resolve_oauth_client(oauth_client, token_url, session)
+        self.rotator = _resolve_rotator(rotator, self.credentials)
 
-    def _sync_rotator(self):
+    def _sync_rotator(self) -> None:
+        """Copy provider rotation state into the configured rotator."""
         self.rotator.credentials = self.credentials
         self.rotator.current_index = self.current_cred_index
 
-    def _sync_index(self):
+    def _sync_index(self) -> None:
+        """Copy rotator position back to the public provider index."""
         self.current_cred_index = self.rotator.current_index
 
-    def _get_current_credential(self):
-        self._sync_rotator()
-        credential = self.token_store.load(self.rotator.next_credential())
-        self._sync_index()
+    def _get_current_credential(self) -> Any:
+        credential = self._load_next_credential()
         return credential.raw
 
-    def _token_needs_refresh(self, cred):
-        credential = self.token_store.load(cred)
+    def _token_needs_refresh(self, cred: Any) -> bool:
+        credential = self._load_credential(cred)
         return self.expiry_policy.needs_refresh(credential)
 
-    def get_token(self):
-        self._sync_rotator()
-        credential = self.token_store.load(self.rotator.next_credential())
-        self._sync_index()
+    def get_token(self) -> Optional[str]:
+        """Return a valid token, refreshing the current credential when needed."""
+        credential = self._load_next_credential()
 
         if self.expiry_policy.needs_refresh(credential):
-            token, ttl = self.oauth_client.fetch_client_credentials_token(credential)
-            credential.token = token
-            credential.token_expiry = self.clock() + ttl
-            self.token_store.save(credential)
+            self._refresh_token(credential)
 
         return credential.token
 
+    def _load_next_credential(self) -> Any:
+        """Rotate to the next credential and load its persisted token state."""
+        self._sync_rotator()
+        credential = self._load_credential(self.rotator.next_credential())
+        self._sync_index()
+        return credential
 
-def _default_token_store_path():
+    def _load_credential(self, credential: Any) -> Any:
+        """Load token state for a specific credential object or mapping."""
+        return self.token_store.load(credential)
+
+    def _refresh_token(self, credential: Any) -> None:
+        """Fetch and persist a fresh OAuth token for a credential."""
+        token, ttl = self.oauth_client.fetch_client_credentials_token(credential)
+        credential.token = token
+        credential.token_expiry = self.clock() + ttl
+        self.token_store.save(credential)
+
+
+def _resolve_clock(clock: Optional[Clock]) -> Clock:
+    """Return the injected clock or the default UTC clock."""
+    return clock or _default_clock
+
+
+def _default_clock() -> datetime:
+    """Return the current UTC time."""
+    return datetime.now(timezone.utc)
+
+
+def _resolve_token_store(token_store: Optional[TokenStore]) -> TokenStore:
+    """Return the injected token store or the default JSON store."""
+    return token_store or JsonTokenStore(_default_token_store_path())
+
+
+def _resolve_expiry_policy(
+    expiry_policy: Optional[TokenExpiryPolicy],
+    clock: Clock,
+) -> TokenExpiryPolicy:
+    """Return the injected expiry policy or one bound to the provider clock."""
+    return expiry_policy or TokenExpiryPolicy(clock=clock)
+
+
+def _resolve_oauth_client(
+    oauth_client: Any,
+    token_url: str,
+    session: Any,
+) -> Any:
+    """Return the injected OAuth client or the default client."""
+    return oauth_client or EbayOAuthClient(token_url, session=session)
+
+
+def _resolve_rotator(
+    rotator: Optional[CredentialRotator],
+    credentials: Any,
+) -> CredentialRotator:
+    """Return the injected rotator or a rotator for provider credentials."""
+    return rotator or CredentialRotator(credentials)
+
+
+def _default_token_store_path() -> Path:
+    """Return the configured token store path."""
     return Path(os.getenv("EBAY_TOKEN_STORE_PATH", ".local/ebay_tokens.json"))

--- a/ebay_client/auth/token_store.py
+++ b/ebay_client/auth/token_store.py
@@ -1,76 +1,119 @@
 import json
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Optional, Union
 
 from .credentials import EbayCredential
 
 
 class TokenStore:
-    def load(self, credential):
+    def load(self, credential: Any) -> Any:
+        """Return a credential object with any persisted token data applied."""
         raise NotImplementedError
 
-    def save(self, credential):
+    def save(self, credential: Any) -> Any:
+        """Persist token data for a credential."""
         raise NotImplementedError
 
 
 class InMemoryTokenStore(TokenStore):
-    def load(self, credential):
-        if hasattr(credential, "raw"):
-            return credential
-        if isinstance(credential, EbayCredential):
-            return credential
-        return EbayCredential.from_mapping(credential)
+    def load(self, credential: Any) -> Any:
+        """Coerce mapping credentials while preserving rotator wrappers."""
+        return _coerce_credential(credential)
 
-    def save(self, credential):
+    def save(self, credential: Any) -> Any:
+        """Persist token data back to a wrapped raw mapping when present."""
         if hasattr(credential, "raw"):
-            credential.raw.update(
-                {
-                    "token": credential.token,
-                    "token_expiry": credential.token_expiry,
-                }
-            )
+            _update_raw_credential(credential)
         return credential
 
 
 class JsonTokenStore(TokenStore):
-    def __init__(self, path):
+    def __init__(self, path: Union[str, Path]) -> None:
         self.path = Path(path)
 
-    def load(self, credential):
-        loaded = InMemoryTokenStore().load(credential)
+    def load(self, credential: Any) -> Any:
+        """Load persisted token data for the supplied credential."""
+        loaded = _coerce_credential(credential)
         tokens = self._read_tokens()
         token_data = tokens.get(loaded.client_id)
         if token_data:
-            loaded.token = token_data.get("token")
-            loaded.token_expiry = _parse_datetime(token_data.get("token_expiry"))
+            _apply_token_data(loaded, token_data)
         return loaded
 
-    def save(self, credential):
+    def save(self, credential: Any) -> Any:
+        """Persist a credential token cache to disk atomically."""
         tokens = self._read_tokens()
-        tokens[credential.client_id] = {
-            "token": credential.token,
-            "token_expiry": (
-                credential.token_expiry.isoformat()
-                if credential.token_expiry is not None
-                else None
-            ),
-        }
+        tokens[credential.client_id] = _serialize_token_data(credential)
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
-        tmp_path.write_text(json.dumps(tokens, indent=2), encoding="utf-8")
-        tmp_path.replace(self.path)
+        self._write_tokens(tokens)
         InMemoryTokenStore().save(credential)
         return credential
 
-    def _read_tokens(self):
+    def _read_tokens(self) -> dict[str, dict[str, Any]]:
         if not self.path.exists():
             return {}
-        return json.loads(self.path.read_text(encoding="utf-8"))
+        with self.path.open(encoding="utf-8") as token_file:
+            return json.load(token_file)
+
+    def _write_tokens(self, tokens: dict[str, dict[str, Any]]) -> None:
+        tmp_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
+        with tmp_path.open("w", encoding="utf-8") as token_file:
+            json.dump(tokens, token_file, indent=2)
+        tmp_path.replace(self.path)
 
 
-def _parse_datetime(value):
+def _coerce_credential(credential: Any) -> Any:
+    """Return a credential object while preserving rotator wrappers."""
+    if hasattr(credential, "raw"):
+        return credential
+    if isinstance(credential, EbayCredential):
+        return credential
+    return EbayCredential.from_mapping(credential)
+
+
+def _update_raw_credential(credential: Any) -> None:
+    """Write token fields back to a rotator wrapper's raw mapping."""
+    credential.raw.update(
+        {
+            "token": credential.token,
+            "token_expiry": credential.token_expiry,
+        }
+    )
+
+
+def _apply_token_data(credential: Any, token_data: dict[str, Any]) -> None:
+    """Apply serialized token fields to a credential."""
+    credential.token = token_data.get("token")
+    credential.token_expiry = _parse_datetime(token_data.get("token_expiry"))
+
+
+def _serialize_token_data(credential: Any) -> dict[str, Optional[str]]:
+    """Convert credential token fields into JSON-safe values."""
+    return {
+        "token": credential.token,
+        "token_expiry": _serialize_datetime(credential.token_expiry),
+    }
+
+
+def _serialize_datetime(value: Optional[datetime]) -> Optional[str]:
+    """Serialize an optional datetime for token storage."""
+    if value is None:
+        return None
+    return value.isoformat()
+
+
+def _parse_datetime(value: Any) -> Optional[datetime]:
+    """Parse token expiry values loaded from JSON."""
     if not value:
         return None
     if isinstance(value, datetime):
         return value
-    return datetime.fromisoformat(value)
+    return datetime.fromisoformat(_normalize_datetime_value(value))
+
+
+def _normalize_datetime_value(value: str) -> str:
+    """Normalize common UTC suffixes for datetime.fromisoformat."""
+    if value.endswith("Z"):
+        return f"{value[:-1]}+00:00"
+    return value

--- a/ebay_client/config/credentials.py
+++ b/ebay_client/config/credentials.py
@@ -1,35 +1,64 @@
 import json
 import os
+from typing import Any, Mapping, Optional
 
 
-def load_ebay_credentials(environ=None):
+def load_ebay_credentials(
+    environ: Optional[Mapping[str, str]] = None,
+) -> list[dict[str, Any]]:
     """Load eBay credential rotation config from environment variables."""
-    environ = environ or os.environ
-    credentials_json = environ.get("EBAY_CREDENTIALS_JSON")
+    env = _environment(environ)
+    credentials_json = _credentials_json(env)
 
     if credentials_json:
-        credentials = json.loads(credentials_json)
-        return [_normalise_credential(credential) for credential in credentials]
+        return _credentials_from_json(credentials_json)
 
-    client_id = environ.get("EBAY_CLIENT_ID")
-    client_secret = environ.get("EBAY_CLIENT_SECRET")
-    if client_id and client_secret:
-        return [
-            {
-                "client_id": client_id,
-                "client_secret": client_secret,
-                "token": environ.get("EBAY_ACCESS_TOKEN"),
-                "token_expiry": None,
-            }
-        ]
-
+    credential = _credential_from_single_env(env)
+    if credential:
+        return [credential]
     return []
 
 
-def _normalise_credential(credential):
+def _environment(environ: Optional[Mapping[str, str]]) -> Mapping[str, str]:
+    """Return the supplied environment mapping or process environment."""
+    return os.environ if environ is None else environ
+
+
+def _credentials_json(environ: Mapping[str, str]) -> Optional[str]:
+    """Return the JSON credential payload from the environment."""
+    return environ.get("EBAY_CREDENTIALS_JSON")
+
+
+def _credentials_from_json(credentials_json: str) -> list[dict[str, Any]]:
+    """Parse and normalize JSON credential rotation data."""
+    credentials = json.loads(credentials_json)
+    return [_normalise_credential(credential) for credential in credentials]
+
+
+def _credential_from_single_env(
+    environ: Mapping[str, str],
+) -> Optional[dict[str, Any]]:
+    """Build a single credential from legacy client ID/secret variables."""
+    client_id = environ.get("EBAY_CLIENT_ID")
+    client_secret = environ.get("EBAY_CLIENT_SECRET")
+
+    if not client_id or not client_secret:
+        return None
+
+    return {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "token": environ.get("EBAY_ACCESS_TOKEN"),
+        "token_expiry": None,
+    }
+
+
+def _normalise_credential(credential: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize supported credential key spellings to snake case."""
     return {
         "client_id": credential.get("client_id") or credential.get("clientId"),
-        "client_secret": credential.get("client_secret") or credential.get("clientSecret"),
+        "client_secret": credential.get("client_secret")
+        or credential.get("clientSecret"),
         "token": credential.get("token"),
         "token_expiry": credential.get("token_expiry"),
     }


### PR DESCRIPTION
## Summary
- Split eBay token provider setup, rotation/index synchronization, credential loading, token refresh, and token-store serialization into smaller helpers.
- Preserve the existing `EbayTokenProvider` constructor and `get_token()` behavior while keeping credential/token mutation compatible with rotator wrappers.
- Add offline coverage for JSON env credentials, single-env fallback, empty env, cached and refreshed tokens, rotator sync, JSON token-store save/load, and datetime parsing.

## Issue
No matching open GitHub issue was provided for this orchestrator task.

## Validation
- `uv run --python 3.11 --with-requirements requirements.txt pytest app/tests/test_ebay_auth_config.py` passed.
- `black .` completed; unrelated repo-wide formatting output was reverted to keep this PR scoped, and the touched files are Black-clean.
- `pytest` was run and failed during collection on existing baseline issues: missing `Query`/`LongTermItem` model exports, missing `archive_items`/`load_historical_items`/`cancel_subscription_logic`, missing `db_session` fixture, and missing `ENCRYPTION_KEY` for `app/tests/test_telegram_notification.py`.
- `uv run --python 3.11 --with-requirements requirements.txt --with mypy mypy .` was run and failed on existing whole-tree typing/stub issues, including missing stubs for requests/WTForms/pytz/pandas/Flask extensions, missing `sentence_transformers`, SQLAlchemy `db.Model` typing, and the same absent test symbols above.
