### PR TITLE
[codex] Refactor eBay analytics utilities

### DIFF
--- a/app/tests/test_ebay_analytics.py
+++ b/app/tests/test_ebay_analytics.py
@@ -1,0 +1,90 @@
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from ebay_client.analytics.client import EbayAnalyticsClient
+from ebay_client.analytics.rate_limits import extract_browse_rate
+
+
+def _rate_limit_payload(rate: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build a minimal eBay analytics payload for Browse rate limit tests."""
+    browse_rate = {"limit": 5000, "remaining": 2500} if rate is None else rate
+    return {
+        "rateLimits": [
+            {
+                "apiContext": "buy",
+                "apiName": "Browse",
+                "resources": [
+                    {
+                        "name": "buy.browse",
+                        "rates": [browse_rate],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_extract_browse_rate_returns_first_matching_rate() -> None:
+    rate = {"limit": 5000, "remaining": 2499, "reset": "2026-04-29T00:00:00.000Z"}
+
+    assert extract_browse_rate(_rate_limit_payload(rate)) == rate
+
+
+def test_extract_browse_rate_preserves_empty_rate() -> None:
+    assert extract_browse_rate(_rate_limit_payload({})) == {}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"rateLimits": []},
+        {"rateLimits": [{"apiContext": "sell", "apiName": "Browse"}]},
+        {
+            "rateLimits": [
+                {
+                    "apiContext": "buy",
+                    "apiName": "Browse",
+                    "resources": [{"name": "buy.browse"}],
+                }
+            ]
+        },
+    ],
+)
+def test_extract_browse_rate_returns_empty_dict_when_missing(
+    payload: dict[str, Any],
+) -> None:
+    assert extract_browse_rate(payload) == {}
+
+
+def test_analytics_client_raises_for_missing_scope() -> None:
+    token_provider = Mock()
+    token_provider.get_token.return_value = "access-token"
+    response = Mock(status_code=403)
+    session = Mock()
+    session.get.return_value = response
+    client = EbayAnalyticsClient(token_provider=token_provider, session=session)
+
+    with pytest.raises(ValueError, match="Missing required scope"):
+        client.get_rate_limits()
+
+    response.raise_for_status.assert_not_called()
+
+
+def test_analytics_client_get_browse_limits_extracts_successful_response() -> None:
+    token_provider = Mock()
+    token_provider.get_token.return_value = "access-token"
+    response = Mock(status_code=200)
+    response.json.return_value = _rate_limit_payload({"limit": 100, "remaining": 50})
+    session = Mock()
+    session.get.return_value = response
+    client = EbayAnalyticsClient(token_provider=token_provider, session=session)
+
+    assert client.get_browse_limits() == {"limit": 100, "remaining": 50}
+    session.get.assert_called_once_with(
+        client.rate_limit_url,
+        headers={"Authorization": "Bearer access-token"},
+    )
+    response.raise_for_status.assert_called_once_with()

--- a/app/tests/test_ebay_utilities.py
+++ b/app/tests/test_ebay_utilities.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from ebay_client.browse.responses import dedupe_items
+from ebay_client.time import parse_ebay_datetime
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (
+            "2026-04-28T15:30:45.123Z",
+            datetime(2026, 4, 28, 15, 30, 45, 123000, tzinfo=timezone.utc),
+        ),
+        (
+            "2026-04-28T15:30:45+00:00",
+            datetime(2026, 4, 28, 15, 30, 45, tzinfo=timezone.utc),
+        ),
+        (
+            "2026-04-28T16:30:45+01:00",
+            datetime(2026, 4, 28, 15, 30, 45, tzinfo=timezone.utc),
+        ),
+    ],
+)
+def test_parse_ebay_datetime_supported_formats(
+    value: str,
+    expected: datetime,
+) -> None:
+    assert parse_ebay_datetime(value) == expected
+
+
+@pytest.mark.parametrize("value", [None, "", "not-a-date"])
+def test_parse_ebay_datetime_invalid_values(value: str | None) -> None:
+    assert parse_ebay_datetime(value) is None
+
+
+def test_dedupe_items_removes_duplicate_ebay_ids() -> None:
+    first_item = {"ebay_id": "v1|123", "title": "first"}
+    duplicate_item = {"ebay_id": "v1|123", "title": "duplicate"}
+    second_item = {"ebay_id": "v1|456", "title": "second"}
+
+    assert dedupe_items([first_item, duplicate_item, second_item]) == [
+        first_item,
+        second_item,
+    ]
+
+
+def test_dedupe_items_keeps_items_without_ebay_id() -> None:
+    items: list[dict[str, Any]] = [
+        {"title": "missing id"},
+        {"ebay_id": None, "title": "none id"},
+        {"ebay_id": "", "title": "empty id"},
+        {"title": "another missing id"},
+    ]
+
+    assert dedupe_items(items) == items

--- a/ebay_client/analytics/client.py
+++ b/ebay_client/analytics/client.py
@@ -1,16 +1,22 @@
+from typing import Any
+
 import requests
 
 from ebay_client.analytics.rate_limits import extract_browse_rate
 
 
 class EbayAnalyticsClient:
+    """Client for eBay developer analytics endpoints."""
+
     rate_limit_url = "https://api.ebay.com/developer/analytics/v1_beta/rate_limit"
 
-    def __init__(self, token_provider, session=None):
+    def __init__(self, token_provider: Any, session: Any | None = None) -> None:
+        """Create an analytics client with a token provider and HTTP session."""
         self.token_provider = token_provider
         self.session = session or requests.Session()
 
-    def get_rate_limits(self):
+    def get_rate_limits(self) -> dict[str, Any]:
+        """Fetch rate limit data from the eBay analytics API."""
         token = self.token_provider.get_token()
         response = self.session.get(
             self.rate_limit_url,
@@ -23,8 +29,14 @@ class EbayAnalyticsClient:
         response.raise_for_status()
         return response.json()
 
-    def get_browse_limits(self, rate_data=None):
+    def get_browse_limits(
+        self, rate_data: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Return Browse API rate limits from provided or fetched rate data."""
         return extract_browse_rate(rate_data or self.get_rate_limits())
 
-    def get_search_limits(self, rate_data=None):
+    def get_search_limits(
+        self, rate_data: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Return search rate limits from provided or fetched rate data."""
         return extract_browse_rate(rate_data or self.get_rate_limits())

--- a/ebay_client/analytics/rate_limits.py
+++ b/ebay_client/analytics/rate_limits.py
@@ -1,7 +1,49 @@
-def extract_browse_rate(rate_data):
-    for limit in rate_data.get("rateLimits", []):
-        if limit.get("apiContext") == "buy" and limit.get("apiName") == "Browse":
-            for resource in limit.get("resources", []):
-                if resource.get("name") == "buy.browse":
-                    return resource["rates"][0]
+from typing import Any
+
+
+def extract_browse_rate(rate_data: dict[str, Any] | None) -> dict[str, Any]:
+    """Return the first Browse API rate limit entry from eBay analytics data."""
+    for limit in _browse_limits(rate_data):
+        rate = _extract_browse_resource_rate(limit)
+        if rate is not None:
+            return rate
     return {}
+
+
+def _browse_limits(rate_data: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Return rate limit groups for the Buy Browse API."""
+    if not rate_data:
+        return []
+
+    return [
+        limit for limit in rate_data.get("rateLimits", []) if _is_browse_limit(limit)
+    ]
+
+
+def _is_browse_limit(limit: dict[str, Any]) -> bool:
+    """Return whether a rate limit group describes the Buy Browse API."""
+    return limit.get("apiContext") == "buy" and limit.get("apiName") == "Browse"
+
+
+def _extract_browse_resource_rate(limit: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the first rate entry for the buy.browse resource."""
+    for resource in _browse_resources(limit):
+        return _first_rate(resource)
+    return None
+
+
+def _browse_resources(limit: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return resources that represent the Browse API."""
+    return [
+        resource
+        for resource in limit.get("resources", [])
+        if resource.get("name") == "buy.browse"
+    ]
+
+
+def _first_rate(resource: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the first rate for a resource, or None when missing."""
+    rates = resource.get("rates", [])
+    if not rates:
+        return None
+    return rates[0]

--- a/ebay_client/browse/responses.py
+++ b/ebay_client/browse/responses.py
@@ -1,12 +1,31 @@
-def dedupe_items(items):
-    seen_ids = set()
-    unique_items = []
+from typing import Any
+
+
+def dedupe_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Remove duplicate items that have the same eBay item identifier."""
+    seen_ids: set[Any] = set()
+    unique_items: list[dict[str, Any]] = []
+
     for item in items:
-        item_id = item.get("ebay_id")
-        if item_id:
-            if item_id not in seen_ids:
-                seen_ids.add(item_id)
-                unique_items.append(item)
-        else:
+        item_id = _dedupe_key(item)
+        if _should_keep_item(item_id, seen_ids):
+            _remember_item_id(item_id, seen_ids)
             unique_items.append(item)
+
     return unique_items
+
+
+def _dedupe_key(item: dict[str, Any]) -> Any:
+    """Return the identifier used to dedupe an item."""
+    return item.get("ebay_id")
+
+
+def _should_keep_item(item_id: Any, seen_ids: set[Any]) -> bool:
+    """Return whether an item should remain in the result list."""
+    return not item_id or item_id not in seen_ids
+
+
+def _remember_item_id(item_id: Any, seen_ids: set[Any]) -> None:
+    """Remember an item identifier when it participates in deduping."""
+    if item_id:
+        seen_ids.add(item_id)

--- a/ebay_client/time.py
+++ b/ebay_client/time.py
@@ -1,16 +1,40 @@
 from datetime import datetime, timezone
+from typing import TypeGuard
 
 
-def parse_ebay_datetime(value):
-    if not value:
+def parse_ebay_datetime(value: str | None) -> datetime | None:
+    """Parse an eBay datetime value into a timezone-aware datetime."""
+    if not _is_datetime_value(value):
         return None
 
+    return _parse_utc_datetime(value) or _parse_iso_datetime(value)
+
+
+def _is_datetime_value(value: str | None) -> TypeGuard[str]:
+    """Return whether a value is a non-empty datetime string."""
+    return isinstance(value, str) and bool(value)
+
+
+def _parse_utc_datetime(value: str) -> datetime | None:
+    """Parse eBay's millisecond UTC timestamp format."""
     try:
         return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ").replace(
             tzinfo=timezone.utc
         )
     except ValueError:
-        try:
-            return datetime.fromisoformat(value.replace("Z", "+00:00"))
-        except ValueError:
-            return None
+        return None
+
+
+def _parse_iso_datetime(value: str) -> datetime | None:
+    """Parse ISO datetimes, including values that end with Z."""
+    try:
+        return datetime.fromisoformat(_normalise_utc_suffix(value))
+    except ValueError:
+        return None
+
+
+def _normalise_utc_suffix(value: str) -> str:
+    """Return a datetime string that datetime.fromisoformat accepts."""
+    if value.endswith("Z"):
+        return f"{value[:-1]}+00:00"
+    return value


### PR DESCRIPTION
## Summary
- Split Browse analytics rate-limit extraction into focused helper functions while keeping the public `extract_browse_rate` API.
- Added typed helper paths for eBay datetime parsing and clearer dedupe helpers for Browse responses.
- Added offline coverage for analytics 403 handling, successful and missing rate extraction, datetime parsing, invalid values, and dedupe behavior.

## Issue
No GitHub issue number was provided for this orchestrator task, so this PR does not auto-close an issue.

## Validation
- `venv/bin/python -m pytest app/tests/test_ebay_analytics.py app/tests/test_ebay_utilities.py` passes: 16 passed.
- `venv/bin/black .` was run; broad formatter churn outside scope was discarded, and scoped files were formatted.
- `venv/bin/mypy ebay_client/analytics/client.py ebay_client/analytics/rate_limits.py ebay_client/time.py ebay_client/browse/responses.py` passes.
- `APP_ENV=testing venv/bin/pytest` currently fails during collection on existing out-of-scope issues: missing `Query`, missing `archive_items`, missing `cancel_subscription_logic`, and missing `ENCRYPTION_KEY`.
- `venv/bin/mypy .` currently fails on existing out-of-scope typing/stub issues across app modules.
