### PR TITLE
[codex] Add search history schema tables

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -8,9 +8,16 @@ from sqlalchemy.dialects.postgresql import NUMERIC, UUID
 from sqlalchemy import JSON, text
 from sqlalchemy.dialects.postgresql import JSONB
 
+JSON_DOCUMENT = JSONB().with_variant(db.JSON(), 'sqlite')
+
+
+class TimestampMixin:
+    """Shared timestamp columns for additive event and history tables."""
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
 
 #For some reason with
-
 class APSchedulerJob(db.Model):
     __tablename__ = 'apscheduler_jobs'
     id = db.Column(db.String(191), primary_key=True)
@@ -147,6 +154,232 @@ class UserQuery(db.Model):
 
     # Relevance average score
     average_relevance_score = db.Column(db.Float, default=0.3)
+
+class SearchRun(TimestampMixin, db.Model):
+    """Execution history for a saved user query."""
+
+    __tablename__ = 'search_runs'
+
+    search_run_id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
+    query_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey('user_queries.query_id', ondelete='CASCADE'),
+        nullable=False,
+        index=True
+    )
+    run_type = db.Column(db.String(30), nullable=False, default='scheduled')
+    status = db.Column(db.String(30), nullable=False, default='started', index=True)
+    source = db.Column(db.String(50))
+    started_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    finished_at = db.Column(db.DateTime)
+    items_seen = db.Column(db.Integer, default=0, nullable=False)
+    items_created = db.Column(db.Integer, default=0, nullable=False)
+    items_updated = db.Column(db.Integer, default=0, nullable=False)
+    error_message = db.Column(db.Text)
+    metadata_json = db.Column(JSON_DOCUMENT, default=dict, nullable=False)
+
+    user_query = db.relationship('UserQuery', backref='search_runs')
+
+
+class ItemObservation(TimestampMixin, db.Model):
+    """Search-specific snapshot of an item seen during execution."""
+
+    __tablename__ = 'item_observations'
+
+    item_observation_id = db.Column(
+        db.BigInteger,
+        primary_key=True,
+        autoincrement=True
+    )
+    search_run_id = db.Column(
+        db.BigInteger,
+        db.ForeignKey('search_runs.search_run_id', ondelete='SET NULL'),
+        index=True
+    )
+    query_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey('user_queries.query_id', ondelete='CASCADE'),
+        nullable=False,
+        index=True
+    )
+    item_id = db.Column(
+        db.BigInteger,
+        db.ForeignKey('items.item_id', ondelete='CASCADE'),
+        nullable=False,
+        index=True
+    )
+    observed_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    price = db.Column(db.Numeric(10, 2))
+    currency = db.Column(db.String(10))
+    current_bid = db.Column(db.Numeric(10, 2))
+    condition = db.Column(db.String(50))
+    buying_options = db.Column(db.String(255))
+    listing_status = db.Column(db.String(50))
+    hard_filter_passed = db.Column(db.Boolean)
+    is_new_item = db.Column(db.Boolean, default=False, nullable=False)
+    raw_item_snapshot = db.Column(JSON_DOCUMENT, default=dict, nullable=False)
+
+    search_run = db.relationship('SearchRun', backref='item_observations')
+    user_query = db.relationship('UserQuery', backref='item_observations')
+    item = db.relationship('Item', backref='observations')
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            'search_run_id',
+            'item_id',
+            name='uq_item_observations_run_item'
+        ),
+    )
+
+
+class UserItemInteraction(TimestampMixin, db.Model):
+    """User feedback or behavior tied to an item and optional query context."""
+
+    __tablename__ = 'user_item_interactions'
+
+    user_item_interaction_id = db.Column(
+        db.BigInteger,
+        primary_key=True,
+        autoincrement=True
+    )
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('users.id', ondelete='CASCADE'),
+        nullable=False,
+        index=True
+    )
+    query_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey('user_queries.query_id', ondelete='SET NULL'),
+        index=True
+    )
+    item_id = db.Column(
+        db.BigInteger,
+        db.ForeignKey('items.item_id', ondelete='CASCADE'),
+        nullable=False,
+        index=True
+    )
+    interaction_type = db.Column(db.String(40), nullable=False, index=True)
+    label = db.Column(db.String(40))
+    source = db.Column(db.String(50))
+    metadata_json = db.Column(JSON_DOCUMENT, default=dict, nullable=False)
+
+    user = db.relationship('User', backref='item_interactions')
+    user_query = db.relationship('UserQuery', backref='item_interactions')
+    item = db.relationship('Item', backref='user_interactions')
+
+
+class ItemFeatureSnapshot(TimestampMixin, db.Model):
+    """Versioned relevance features extracted for an item/query pair."""
+
+    __tablename__ = 'item_feature_snapshots'
+
+    item_feature_snapshot_id = db.Column(
+        db.BigInteger,
+        primary_key=True,
+        autoincrement=True
+    )
+    query_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey('user_queries.query_id', ondelete='CASCADE'),
+        nullable=False,
+        index=True
+    )
+    item_id = db.Column(
+        db.BigInteger,
+        db.ForeignKey('items.item_id', ondelete='CASCADE'),
+        nullable=False,
+        index=True
+    )
+    search_run_id = db.Column(
+        db.BigInteger,
+        db.ForeignKey('search_runs.search_run_id', ondelete='SET NULL'),
+        index=True
+    )
+    feature_version = db.Column(db.String(40), nullable=False, default='v1')
+    model_version = db.Column(db.String(80))
+    features = db.Column(JSON_DOCUMENT, default=dict, nullable=False)
+    relevance_score = db.Column(db.Float)
+    should_notify = db.Column(db.Boolean)
+    decision = db.Column(db.String(40))
+
+    user_query = db.relationship('UserQuery', backref='feature_snapshots')
+    item = db.relationship('Item', backref='feature_snapshots')
+    search_run = db.relationship('SearchRun', backref='feature_snapshots')
+
+
+class DomainEvent(TimestampMixin, db.Model):
+    """Durable domain event for downstream notification processing."""
+
+    __tablename__ = 'domain_events'
+
+    domain_event_id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
+    event_type = db.Column(db.String(80), nullable=False, index=True)
+    aggregate_type = db.Column(db.String(50), nullable=False)
+    aggregate_id = db.Column(db.String(100), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id', ondelete='SET NULL'))
+    query_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey('user_queries.query_id', ondelete='SET NULL')
+    )
+    item_id = db.Column(
+        db.BigInteger,
+        db.ForeignKey('items.item_id', ondelete='SET NULL')
+    )
+    status = db.Column(db.String(30), nullable=False, default='pending', index=True)
+    source = db.Column(db.String(50))
+    payload = db.Column(JSON_DOCUMENT, default=dict, nullable=False)
+    occurred_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    processed_at = db.Column(db.DateTime)
+
+    user = db.relationship('User', backref='domain_events')
+    user_query = db.relationship('UserQuery', backref='domain_events')
+    item = db.relationship('Item', backref='domain_events')
+
+
+class NotificationRecord(TimestampMixin, db.Model):
+    """Delivery audit trail for notifications emitted from domain events."""
+
+    __tablename__ = 'notification_records'
+
+    notification_record_id = db.Column(
+        db.BigInteger,
+        primary_key=True,
+        autoincrement=True
+    )
+    domain_event_id = db.Column(
+        db.BigInteger,
+        db.ForeignKey('domain_events.domain_event_id', ondelete='SET NULL'),
+        index=True
+    )
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('users.id', ondelete='CASCADE'),
+        nullable=False,
+        index=True
+    )
+    query_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey('user_queries.query_id', ondelete='SET NULL'),
+        index=True
+    )
+    item_id = db.Column(
+        db.BigInteger,
+        db.ForeignKey('items.item_id', ondelete='SET NULL'),
+        index=True
+    )
+    channel = db.Column(db.String(40), nullable=False)
+    notification_type = db.Column(db.String(60), nullable=False)
+    status = db.Column(db.String(30), nullable=False, default='pending', index=True)
+    recipient = db.Column(db.String(255))
+    payload = db.Column(JSON_DOCUMENT, default=dict, nullable=False)
+    error_message = db.Column(db.Text)
+    sent_at = db.Column(db.DateTime)
+
+    domain_event = db.relationship('DomainEvent', backref='notification_records')
+    user = db.relationship('User', backref='notification_records')
+    user_query = db.relationship('UserQuery', backref='notification_records')
+    item = db.relationship('Item', backref='notification_records')
 
 class Keyword(db.Model):
     __tablename__ = 'keywords'

--- a/app/models.py
+++ b/app/models.py
@@ -8,6 +8,9 @@ from sqlalchemy.dialects.postgresql import NUMERIC, UUID
 from sqlalchemy import JSON, text
 from sqlalchemy.dialects.postgresql import JSONB
 
+
+#For some reason with
+
 JSON_DOCUMENT = JSONB().with_variant(db.JSON(), 'sqlite')
 
 
@@ -17,7 +20,6 @@ class TimestampMixin:
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
-#For some reason with
 class APSchedulerJob(db.Model):
     __tablename__ = 'apscheduler_jobs'
     id = db.Column(db.String(191), primary_key=True)

--- a/docs/backend_refactor_plan.md
+++ b/docs/backend_refactor_plan.md
@@ -20,6 +20,29 @@ This repo is moving toward a backend-first modular structure for an eBay notifie
 4. Expand relevance around explicit interactions: relevant, not relevant, clicked, dismissed, notified, ignored, purchased.
 5. Replace the current heuristic relevance scorer with a trained classifier behind the same service boundary when enough feedback exists.
 
+## Additive schema direction
+
+The compatibility model remains `UserQuery` for the current route, scheduler, and repository code. The next schema increment adds history and event tables around it instead of destructively splitting it:
+
+- `SearchRun` records each scheduled, preview, manual, or recent/full execution attempt.
+- `ItemObservation` records the item/query/search-run snapshot after hard filters and before relevance decisions.
+- `ItemFeatureSnapshot` stores versioned feature dictionaries and relevance decisions for a query/item pair.
+- `UserItemInteraction` stores explicit and implicit labels such as clicked, dismissed, relevant, not relevant, notified, ignored, or purchased.
+- `DomainEvent` provides a durable handoff from search/relevance decisions to downstream processors.
+- `NotificationRecord` audits attempted and completed notification deliveries.
+
+Legacy `required_keywords` and `excluded_keywords` stay on `UserQuery` as hard filters. `ItemRelevanceFeedback`, `Feedback`, `UserQueryItems`, `Keyword`, and `Item` remain available while services move toward learned preference and relevance.
+
+## Deferred saved search split
+
+Do not split `UserQuery` in the current additive pass. Once repositories and route code depend on domain interfaces instead of the legacy model, introduce compatible tables with a backfill migration:
+
+- `saved_searches`: stable search identity, owner, marketplace, active flag, and keyword reference.
+- `search_info`: user-editable filters and display metadata, including hard keyword filters.
+- `search_status`: schedule and execution state such as first run, last full/recent run, and next full run.
+
+The target application contract should continue to expose `SavedSearch`, `SearchFilters`, and `SearchSchedule`, with `saved_search_from_model(user_query)` and `to_ebay_search_params(saved_search)` preserving existing behavior during the transition.
+
 ## Configuration
 
 Committed eBay credentials were removed. Configure eBay access with either:

--- a/migrations/versions/6f2a9c1b8d7e_add_search_history_and_events.py
+++ b/migrations/versions/6f2a9c1b8d7e_add_search_history_and_events.py
@@ -1,0 +1,331 @@
+"""Add search history, interaction, event, and notification tables.
+
+Revision ID: 6f2a9c1b8d7e
+Revises: 79e5d4e6caa5
+Create Date: 2026-04-28 15:25:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "6f2a9c1b8d7e"
+down_revision = "79e5d4e6caa5"
+branch_labels = None
+depends_on = None
+
+
+JSON_DOCUMENT = postgresql.JSONB(astext_type=sa.Text()).with_variant(
+    sa.JSON(), "sqlite"
+)
+
+
+def upgrade():
+    op.create_table(
+        "search_runs",
+        sa.Column("search_run_id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("query_id", sa.UUID(), nullable=False),
+        sa.Column("run_type", sa.String(length=30), nullable=False),
+        sa.Column("status", sa.String(length=30), nullable=False),
+        sa.Column("source", sa.String(length=50), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=False),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.Column("items_seen", sa.Integer(), nullable=False),
+        sa.Column("items_created", sa.Integer(), nullable=False),
+        sa.Column("items_updated", sa.Integer(), nullable=False),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("metadata_json", JSON_DOCUMENT, nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["query_id"], ["user_queries.query_id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("search_run_id"),
+    )
+    op.create_index("ix_search_runs_query_id", "search_runs", ["query_id"])
+    op.create_index("ix_search_runs_status", "search_runs", ["status"])
+    op.create_index(
+        "ix_search_runs_query_started_at", "search_runs", ["query_id", "started_at"]
+    )
+
+    op.create_table(
+        "item_observations",
+        sa.Column(
+            "item_observation_id", sa.BigInteger(), autoincrement=True, nullable=False
+        ),
+        sa.Column("search_run_id", sa.BigInteger(), nullable=True),
+        sa.Column("query_id", sa.UUID(), nullable=False),
+        sa.Column("item_id", sa.BigInteger(), nullable=False),
+        sa.Column("observed_at", sa.DateTime(), nullable=False),
+        sa.Column("price", sa.Numeric(precision=10, scale=2), nullable=True),
+        sa.Column("currency", sa.String(length=10), nullable=True),
+        sa.Column("current_bid", sa.Numeric(precision=10, scale=2), nullable=True),
+        sa.Column("condition", sa.String(length=50), nullable=True),
+        sa.Column("buying_options", sa.String(length=255), nullable=True),
+        sa.Column("listing_status", sa.String(length=50), nullable=True),
+        sa.Column("hard_filter_passed", sa.Boolean(), nullable=True),
+        sa.Column("is_new_item", sa.Boolean(), nullable=False),
+        sa.Column("raw_item_snapshot", JSON_DOCUMENT, nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["item_id"], ["items.item_id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["query_id"], ["user_queries.query_id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["search_run_id"], ["search_runs.search_run_id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("item_observation_id"),
+        sa.UniqueConstraint(
+            "search_run_id", "item_id", name="uq_item_observations_run_item"
+        ),
+    )
+    op.create_index(
+        "ix_item_observations_search_run_id", "item_observations", ["search_run_id"]
+    )
+    op.create_index("ix_item_observations_query_id", "item_observations", ["query_id"])
+    op.create_index("ix_item_observations_item_id", "item_observations", ["item_id"])
+    op.create_index(
+        "ix_item_observations_query_item_observed_at",
+        "item_observations",
+        ["query_id", "item_id", "observed_at"],
+    )
+
+    op.create_table(
+        "user_item_interactions",
+        sa.Column(
+            "user_item_interaction_id",
+            sa.BigInteger(),
+            autoincrement=True,
+            nullable=False,
+        ),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("query_id", sa.UUID(), nullable=True),
+        sa.Column("item_id", sa.BigInteger(), nullable=False),
+        sa.Column("interaction_type", sa.String(length=40), nullable=False),
+        sa.Column("label", sa.String(length=40), nullable=True),
+        sa.Column("source", sa.String(length=50), nullable=True),
+        sa.Column("metadata_json", JSON_DOCUMENT, nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["item_id"], ["items.item_id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["query_id"], ["user_queries.query_id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_item_interaction_id"),
+    )
+    op.create_index(
+        "ix_user_item_interactions_interaction_type",
+        "user_item_interactions",
+        ["interaction_type"],
+    )
+    op.create_index(
+        "ix_user_item_interactions_item_id", "user_item_interactions", ["item_id"]
+    )
+    op.create_index(
+        "ix_user_item_interactions_query_id", "user_item_interactions", ["query_id"]
+    )
+    op.create_index(
+        "ix_user_item_interactions_user_id", "user_item_interactions", ["user_id"]
+    )
+    op.create_index(
+        "ix_user_item_interactions_user_item_created_at",
+        "user_item_interactions",
+        ["user_id", "item_id", "created_at"],
+    )
+
+    op.create_table(
+        "item_feature_snapshots",
+        sa.Column(
+            "item_feature_snapshot_id",
+            sa.BigInteger(),
+            autoincrement=True,
+            nullable=False,
+        ),
+        sa.Column("query_id", sa.UUID(), nullable=False),
+        sa.Column("item_id", sa.BigInteger(), nullable=False),
+        sa.Column("search_run_id", sa.BigInteger(), nullable=True),
+        sa.Column("feature_version", sa.String(length=40), nullable=False),
+        sa.Column("model_version", sa.String(length=80), nullable=True),
+        sa.Column("features", JSON_DOCUMENT, nullable=False),
+        sa.Column("relevance_score", sa.Float(), nullable=True),
+        sa.Column("should_notify", sa.Boolean(), nullable=True),
+        sa.Column("decision", sa.String(length=40), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["item_id"], ["items.item_id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["query_id"], ["user_queries.query_id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["search_run_id"], ["search_runs.search_run_id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("item_feature_snapshot_id"),
+    )
+    op.create_index(
+        "ix_item_feature_snapshots_item_id", "item_feature_snapshots", ["item_id"]
+    )
+    op.create_index(
+        "ix_item_feature_snapshots_query_id", "item_feature_snapshots", ["query_id"]
+    )
+    op.create_index(
+        "ix_item_feature_snapshots_search_run_id",
+        "item_feature_snapshots",
+        ["search_run_id"],
+    )
+    op.create_index(
+        "ix_item_feature_snapshots_query_item_created_at",
+        "item_feature_snapshots",
+        ["query_id", "item_id", "created_at"],
+    )
+
+    op.create_table(
+        "domain_events",
+        sa.Column(
+            "domain_event_id", sa.BigInteger(), autoincrement=True, nullable=False
+        ),
+        sa.Column("event_type", sa.String(length=80), nullable=False),
+        sa.Column("aggregate_type", sa.String(length=50), nullable=False),
+        sa.Column("aggregate_id", sa.String(length=100), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("query_id", sa.UUID(), nullable=True),
+        sa.Column("item_id", sa.BigInteger(), nullable=True),
+        sa.Column("status", sa.String(length=30), nullable=False),
+        sa.Column("source", sa.String(length=50), nullable=True),
+        sa.Column("payload", JSON_DOCUMENT, nullable=False),
+        sa.Column("occurred_at", sa.DateTime(), nullable=False),
+        sa.Column("processed_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["item_id"], ["items.item_id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["query_id"], ["user_queries.query_id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("domain_event_id"),
+    )
+    op.create_index("ix_domain_events_event_type", "domain_events", ["event_type"])
+    op.create_index("ix_domain_events_status", "domain_events", ["status"])
+    op.create_index(
+        "ix_domain_events_status_occurred_at",
+        "domain_events",
+        ["status", "occurred_at"],
+    )
+
+    op.create_table(
+        "notification_records",
+        sa.Column(
+            "notification_record_id",
+            sa.BigInteger(),
+            autoincrement=True,
+            nullable=False,
+        ),
+        sa.Column("domain_event_id", sa.BigInteger(), nullable=True),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("query_id", sa.UUID(), nullable=True),
+        sa.Column("item_id", sa.BigInteger(), nullable=True),
+        sa.Column("channel", sa.String(length=40), nullable=False),
+        sa.Column("notification_type", sa.String(length=60), nullable=False),
+        sa.Column("status", sa.String(length=30), nullable=False),
+        sa.Column("recipient", sa.String(length=255), nullable=True),
+        sa.Column("payload", JSON_DOCUMENT, nullable=False),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("sent_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["domain_event_id"], ["domain_events.domain_event_id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["item_id"], ["items.item_id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["query_id"], ["user_queries.query_id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("notification_record_id"),
+    )
+    op.create_index(
+        "ix_notification_records_domain_event_id",
+        "notification_records",
+        ["domain_event_id"],
+    )
+    op.create_index(
+        "ix_notification_records_item_id", "notification_records", ["item_id"]
+    )
+    op.create_index(
+        "ix_notification_records_query_id", "notification_records", ["query_id"]
+    )
+    op.create_index(
+        "ix_notification_records_status", "notification_records", ["status"]
+    )
+    op.create_index(
+        "ix_notification_records_user_id", "notification_records", ["user_id"]
+    )
+    op.create_index(
+        "ix_notification_records_user_status_created_at",
+        "notification_records",
+        ["user_id", "status", "created_at"],
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "ix_notification_records_user_status_created_at",
+        table_name="notification_records",
+    )
+    op.drop_index("ix_notification_records_user_id", table_name="notification_records")
+    op.drop_index("ix_notification_records_status", table_name="notification_records")
+    op.drop_index("ix_notification_records_query_id", table_name="notification_records")
+    op.drop_index("ix_notification_records_item_id", table_name="notification_records")
+    op.drop_index(
+        "ix_notification_records_domain_event_id", table_name="notification_records"
+    )
+    op.drop_table("notification_records")
+
+    op.drop_index("ix_domain_events_status_occurred_at", table_name="domain_events")
+    op.drop_index("ix_domain_events_status", table_name="domain_events")
+    op.drop_index("ix_domain_events_event_type", table_name="domain_events")
+    op.drop_table("domain_events")
+
+    op.drop_index(
+        "ix_item_feature_snapshots_query_item_created_at",
+        table_name="item_feature_snapshots",
+    )
+    op.drop_index(
+        "ix_item_feature_snapshots_search_run_id", table_name="item_feature_snapshots"
+    )
+    op.drop_index(
+        "ix_item_feature_snapshots_query_id", table_name="item_feature_snapshots"
+    )
+    op.drop_index(
+        "ix_item_feature_snapshots_item_id", table_name="item_feature_snapshots"
+    )
+    op.drop_table("item_feature_snapshots")
+
+    op.drop_index(
+        "ix_user_item_interactions_user_item_created_at",
+        table_name="user_item_interactions",
+    )
+    op.drop_index(
+        "ix_user_item_interactions_user_id", table_name="user_item_interactions"
+    )
+    op.drop_index(
+        "ix_user_item_interactions_query_id", table_name="user_item_interactions"
+    )
+    op.drop_index(
+        "ix_user_item_interactions_item_id", table_name="user_item_interactions"
+    )
+    op.drop_index(
+        "ix_user_item_interactions_interaction_type",
+        table_name="user_item_interactions",
+    )
+    op.drop_table("user_item_interactions")
+
+    op.drop_index(
+        "ix_item_observations_query_item_observed_at", table_name="item_observations"
+    )
+    op.drop_index("ix_item_observations_item_id", table_name="item_observations")
+    op.drop_index("ix_item_observations_query_id", table_name="item_observations")
+    op.drop_index("ix_item_observations_search_run_id", table_name="item_observations")
+    op.drop_table("item_observations")
+
+    op.drop_index("ix_search_runs_query_started_at", table_name="search_runs")
+    op.drop_index("ix_search_runs_status", table_name="search_runs")
+    op.drop_index("ix_search_runs_query_id", table_name="search_runs")
+    op.drop_table("search_runs")


### PR DESCRIPTION
## Summary
- Add additive SQLAlchemy models for search runs, item observations, item feature snapshots, user item interactions, domain events, and notification records.
- Add an Alembic revision that creates the new tables and supporting indexes without splitting or removing legacy models.
- Document the deferred `saved_searches` / `search_info` / `search_status` split and preserved hard-filter behavior.

Closes #16.

## Validation
- `python3 -m compileall app ebay_client config.py` passed.
- Imported the new model classes from `app.models` successfully.
- Rendered the new Alembic revision to PostgreSQL SQL offline successfully.
- `black .` ran in a clean temporary worktree; out-of-scope formatter churn was restored before commit.
- `pytest` currently fails during collection on pre-existing missing symbols (`Query`, `archive_items`, `load_historical_items`, `cancel_subscription_logic`) and a missing local Postgres scheduler connection.
- `mypy .` currently fails on existing project-wide missing stubs/typing issues and legacy missing test symbols.

## Notes
- No migrations beyond `6f2a9c1b8d7e_add_search_history_and_events.py`.
- `ebay_client/` was not edited.
- Legacy `User`, `UserQuery`, `Keyword`, `Item`, `UserQueryItems`, `ItemRelevanceFeedback`, and `Feedback` remain available.
