### PR TITLE
[codex] Add relevance foundation

### DIFF
--- a/app/relevance/__init__.py
+++ b/app/relevance/__init__.py
@@ -1,4 +1,13 @@
+from app.relevance.domain import RelevanceDecision, RelevanceInteraction
 from app.relevance.feedback import RelevanceFeedbackService
-from app.relevance.scoring import BaselineRelevanceScorer, RelevanceDecision
+from app.relevance.scoring import BaselineRelevanceScorer, RelevanceScorer
+from app.relevance.service import RelevanceService
 
-__all__ = ["BaselineRelevanceScorer", "RelevanceDecision", "RelevanceFeedbackService"]
+__all__ = [
+    "BaselineRelevanceScorer",
+    "RelevanceDecision",
+    "RelevanceFeedbackService",
+    "RelevanceInteraction",
+    "RelevanceScorer",
+    "RelevanceService",
+]

--- a/app/relevance/domain.py
+++ b/app/relevance/domain.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RelevanceDecision:
+    """Decision returned by relevance scoring before notification dispatch."""
+
+    score: float
+    should_notify: bool
+    reasons: tuple[str, ...] = ()
+    features: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RelevanceInteraction:
+    """Recorded interaction hook for future training data capture."""
+
+    user_id: int
+    search_id: str
+    item_id: str
+    interaction_type: str
+    label: str | None = None
+    source: str | None = None
+    persisted: bool = False

--- a/app/relevance/features.py
+++ b/app/relevance/features.py
@@ -1,0 +1,167 @@
+import re
+from collections.abc import Mapping
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from app.utils.text_helpers import remove_accents
+
+ACCESSORY_TERMS = {
+    "case",
+    "cases",
+    "cover",
+    "covers",
+    "protector",
+    "screen",
+    "charger",
+    "cable",
+    "mount",
+    "holder",
+}
+
+
+def extract_item_features(saved_search: Any, item: Any) -> dict[str, Any]:
+    """Extract reusable search and item features for relevance decisions."""
+
+    query_text = _query_text(saved_search)
+    title = _string_value(_value(item, "title"))
+    description = _string_value(_value(item, "description"))
+    title_terms = terms(title)
+    query_terms = terms(query_text)
+    required_keywords = keyword_list(_filter_value(saved_search, "required_keywords"))
+    excluded_keywords = keyword_list(_filter_value(saved_search, "excluded_keywords"))
+    item_text = f"{title} {description}".strip()
+
+    return {
+        "saved_search_id": _string_value(
+            _value(saved_search, "id") or _value(saved_search, "query_id")
+        ),
+        "item_id": _string_value(_value(item, "item_id") or _value(item, "id")),
+        "query_text": query_text,
+        "title": title,
+        "description": description,
+        "query_terms": query_terms,
+        "title_terms": title_terms,
+        "required_keywords": required_keywords,
+        "excluded_keywords": excluded_keywords,
+        "required_keywords_present": _required_keywords_present(
+            item_text, required_keywords
+        ),
+        "excluded_keywords_present": _excluded_keywords_present(
+            item_text, excluded_keywords
+        ),
+        "query_term_count": len(query_terms),
+        "query_term_match_count": len(query_terms & title_terms),
+        "query_match_ratio": _query_match_ratio(query_terms, title_terms),
+        "accessory_terms_present": bool(ACCESSORY_TERMS & title_terms),
+        "query_has_accessory_terms": bool(ACCESSORY_TERMS & query_terms),
+        "price": _decimal_value(_value(item, "price")),
+        "min_price": _decimal_value(_filter_value(saved_search, "min_price")),
+        "max_price": _decimal_value(_filter_value(saved_search, "max_price")),
+        "condition": _normalized_optional(_value(item, "condition")),
+        "expected_condition": _normalized_optional(
+            _filter_value(saved_search, "condition")
+        ),
+        "location_country": _normalized_optional(
+            _value(item, "location_country")
+            or _nested_value(item, "location", "country")
+        ),
+        "expected_location": _normalized_optional(
+            _filter_value(saved_search, "item_location")
+        ),
+        "buying_options": _normalized_optional(_value(item, "buying_options")),
+        "expected_buying_options": _normalized_optional(
+            _filter_value(saved_search, "buying_options")
+        ),
+    }
+
+
+def terms(text: str | None) -> set[str]:
+    """Return normalized alphanumeric terms from text."""
+
+    normalized = remove_accents((text or "").lower())
+    return set(re.findall(r"[a-z0-9]+", normalized))
+
+
+def keyword_list(value: Any) -> tuple[str, ...]:
+    """Parse comma-separated keyword filters into normalized terms."""
+
+    if not value:
+        return ()
+    return tuple(
+        remove_accents(keyword.strip().lower())
+        for keyword in str(value).split(",")
+        if keyword.strip()
+    )
+
+
+def _query_text(saved_search: Any) -> str:
+    keyword = _value(saved_search, "keyword")
+    keyword_text = _value(keyword, "keyword_text") if keyword else None
+    return _string_value(
+        _value(saved_search, "keywords")
+        or keyword_text
+        or _value(saved_search, "keyword_text")
+    )
+
+
+def _filter_value(saved_search: Any, name: str) -> Any:
+    filters = _value(saved_search, "filters")
+    value = _value(filters, name) if filters is not None else None
+    if value is not None:
+        return value
+    return _value(saved_search, name)
+
+
+def _value(source: Any, name: str) -> Any:
+    if source is None:
+        return None
+    if isinstance(source, Mapping):
+        return source.get(name)
+    return getattr(source, name, None)
+
+
+def _nested_value(source: Any, outer: str, inner: str) -> Any:
+    nested = _value(source, outer)
+    return _value(nested, inner)
+
+
+def _string_value(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _normalized_optional(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip().upper()
+    return normalized or None
+
+
+def _decimal_value(value: Any) -> Decimal | None:
+    if value in (None, ""):
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
+def _query_match_ratio(query_terms: set[str], title_terms: set[str]) -> float:
+    if not query_terms:
+        return 0.5
+    return len(query_terms & title_terms) / len(query_terms)
+
+
+def _required_keywords_present(text: str, required_keywords: tuple[str, ...]) -> bool:
+    if not required_keywords:
+        return True
+    normalized = remove_accents(text.lower())
+    return all(keyword in normalized for keyword in required_keywords)
+
+
+def _excluded_keywords_present(text: str, excluded_keywords: tuple[str, ...]) -> bool:
+    if not excluded_keywords:
+        return False
+    normalized = remove_accents(text.lower())
+    return any(keyword in normalized for keyword in excluded_keywords)

--- a/app/relevance/feedback.py
+++ b/app/relevance/feedback.py
@@ -19,8 +19,12 @@ class RelevanceFeedbackService:
         is_relevant = feedback == "relevant"
         if feedback_entry:
             feedback_entry.is_relevant = is_relevant
-            feedback_entry.required_keywords = user_query_item.user_query.required_keywords
-            feedback_entry.excluded_keywords = user_query_item.user_query.excluded_keywords
+            feedback_entry.required_keywords = (
+                user_query_item.user_query.required_keywords
+            )
+            feedback_entry.excluded_keywords = (
+                user_query_item.user_query.excluded_keywords
+            )
         else:
             feedback_entry = ItemRelevanceFeedback(
                 user_id=user.id,

--- a/app/relevance/repository.py
+++ b/app/relevance/repository.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from importlib import import_module
 from typing import Any, Protocol
 
 from app.extensions import db
@@ -32,8 +33,13 @@ class RelevanceRepository(Protocol):
 class SqlAlchemyRelevanceRepository:
     """Default adapter over the legacy relevance feedback table."""
 
-    def __init__(self, session: Any | None = None) -> None:
+    def __init__(
+        self,
+        session: Any | None = None,
+        interaction_repository: Any | None = None,
+    ) -> None:
         self.session = session or db.session
+        self.interactions = interaction_repository
 
     def get_feedback(
         self,
@@ -69,10 +75,73 @@ class SqlAlchemyRelevanceRepository:
             source=source,
             persisted=False,
         )
+        if self._interaction_schema_available():
+            persisted = self._record_user_item_interaction(
+                user_id=user_id,
+                search_id=search_id,
+                item_id=item_id,
+                interaction_type=interaction_type,
+                label=label,
+                source=source,
+            )
+            if persisted is not None:
+                return _persisted_interaction(interaction)
+
         relevance_label = _label_to_bool(label)
         if relevance_label is None:
             return interaction
 
+        return self._record_legacy_feedback(
+            interaction=interaction,
+            user_id=user_id,
+            search_id=search_id,
+            item_id=item_id,
+            relevance_label=relevance_label,
+        )
+
+    def _interaction_schema_available(self) -> bool:
+        if self.interactions is not None:
+            return True
+        if _optional_model("UserItemInteraction") is None:
+            return False
+        self.interactions = _optional_interaction_repository(self.session)
+        return self.interactions is not None
+
+    def _record_user_item_interaction(
+        self,
+        user_id: int,
+        search_id: str,
+        item_id: str,
+        interaction_type: str,
+        label: str | None,
+        source: str | None,
+    ) -> object | None:
+        if self.interactions is None:
+            return None
+
+        metadata_json = _interaction_metadata(search_id)
+        for payload in _interaction_payloads(
+            user_id=user_id,
+            search_id=search_id,
+            item_id=item_id,
+            interaction_type=interaction_type,
+            label=label,
+            source=source,
+            metadata_json=metadata_json,
+        ):
+            persisted = _call_record_interaction(self.interactions, payload)
+            if persisted is not None:
+                return persisted
+        return None
+
+    def _record_legacy_feedback(
+        self,
+        interaction: RelevanceInteraction,
+        user_id: int,
+        search_id: str,
+        item_id: str,
+        relevance_label: bool,
+    ) -> RelevanceInteraction:
         query = UserQuery.query.filter_by(query_id=search_id).one_or_none()
         if query is None:
             return interaction
@@ -97,15 +166,113 @@ class SqlAlchemyRelevanceRepository:
         feedback.required_keywords = query.required_keywords
         feedback.excluded_keywords = query.excluded_keywords
         self.session.flush()
-        return RelevanceInteraction(
-            user_id=user_id,
-            search_id=str(search_id),
-            item_id=str(item_id),
-            interaction_type=interaction_type,
-            label=label,
-            source=source,
-            persisted=True,
-        )
+        return _persisted_interaction(interaction)
+
+
+def _persisted_interaction(interaction: RelevanceInteraction) -> RelevanceInteraction:
+    return RelevanceInteraction(
+        user_id=interaction.user_id,
+        search_id=interaction.search_id,
+        item_id=interaction.item_id,
+        interaction_type=interaction.interaction_type,
+        label=interaction.label,
+        source=interaction.source,
+        persisted=True,
+    )
+
+
+def _optional_model(name: str) -> type[Any] | None:
+    try:
+        models = import_module("app.models")
+    except ImportError:
+        return None
+    return getattr(models, name, None)
+
+
+def _optional_interaction_repository(session: Any) -> Any | None:
+    try:
+        repositories = import_module("app.repositories")
+    except ImportError:
+        return None
+    repository_class = getattr(repositories, "InteractionRepository", None)
+    if repository_class is None:
+        return None
+    try:
+        return repository_class(session=session)
+    except TypeError:
+        return repository_class()
+
+
+def _interaction_metadata(search_id: str) -> dict[str, str]:
+    return {"search_id": str(search_id)}
+
+
+def _interaction_payloads(
+    user_id: int,
+    search_id: str,
+    item_id: str,
+    interaction_type: str,
+    label: str | None,
+    source: str | None,
+    metadata_json: dict[str, str],
+) -> tuple[dict[str, Any], ...]:
+    base_payload = {
+        "user_id": user_id,
+        "item_id": item_id,
+        "interaction_type": interaction_type,
+        "label": label,
+        "source": source,
+    }
+    with_query_id = {
+        **base_payload,
+        "query_id": search_id,
+        "metadata_json": metadata_json,
+    }
+    with_search_id = {
+        **base_payload,
+        "search_id": search_id,
+        "metadata_json": metadata_json,
+    }
+    return (
+        with_query_id,
+        with_search_id,
+        {key: value for key, value in with_query_id.items() if key != "metadata_json"},
+        {key: value for key, value in with_search_id.items() if key != "metadata_json"},
+    )
+
+
+def _call_record_interaction(repository: Any, payload: dict[str, Any]) -> object | None:
+    added_record = _call_add_interaction_record(repository, payload)
+    if added_record is not None:
+        return added_record
+
+    recorder = getattr(repository, "record_interaction", None)
+    if recorder is None:
+        recorder = getattr(repository, "record", None)
+    if recorder is None:
+        return None
+    try:
+        return recorder(**payload)
+    except TypeError:
+        return None
+
+
+def _call_add_interaction_record(
+    repository: Any,
+    payload: dict[str, Any],
+) -> object | None:
+    if "query_id" not in payload:
+        return None
+
+    values = getattr(repository, "values", None)
+    add = getattr(repository, "add", None)
+    if values is None or add is None:
+        return None
+
+    try:
+        return add(values(**payload))
+    except TypeError:
+        return None
 
 
 def _object_id(source: Any, *names: str) -> Any:

--- a/app/relevance/repository.py
+++ b/app/relevance/repository.py
@@ -1,0 +1,147 @@
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from app.extensions import db
+from app.models import ItemRelevanceFeedback, UserQuery
+from app.relevance.domain import RelevanceInteraction
+
+
+class RelevanceRepository(Protocol):
+    """Storage contract used by RelevanceService."""
+
+    def get_feedback(
+        self,
+        user_id: int,
+        saved_search: Any,
+        item: Any,
+    ) -> Any | None:
+        """Return stored user feedback for this search item, if available."""
+
+    def record_interaction(
+        self,
+        user_id: int,
+        search_id: str,
+        item_id: str,
+        interaction_type: str,
+        label: str | None = None,
+        source: str | None = None,
+    ) -> object:
+        """Record a user interaction for later model training."""
+
+
+class SqlAlchemyRelevanceRepository:
+    """Default adapter over the legacy relevance feedback table."""
+
+    def __init__(self, session: Any | None = None) -> None:
+        self.session = session or db.session
+
+    def get_feedback(
+        self,
+        user_id: int,
+        saved_search: Any,
+        item: Any,
+    ) -> ItemRelevanceFeedback | None:
+        item_id = _object_id(item, "item_id", "id")
+        keyword_id = _keyword_id(saved_search)
+        if item_id is None or keyword_id is None:
+            return None
+        return ItemRelevanceFeedback.query.filter_by(
+            user_id=user_id,
+            item_id=item_id,
+            keyword_id=keyword_id,
+        ).one_or_none()
+
+    def record_interaction(
+        self,
+        user_id: int,
+        search_id: str,
+        item_id: str,
+        interaction_type: str,
+        label: str | None = None,
+        source: str | None = None,
+    ) -> object:
+        interaction = RelevanceInteraction(
+            user_id=user_id,
+            search_id=str(search_id),
+            item_id=str(item_id),
+            interaction_type=interaction_type,
+            label=label,
+            source=source,
+            persisted=False,
+        )
+        relevance_label = _label_to_bool(label)
+        if relevance_label is None:
+            return interaction
+
+        query = UserQuery.query.filter_by(query_id=search_id).one_or_none()
+        if query is None:
+            return interaction
+
+        feedback = ItemRelevanceFeedback.query.filter_by(
+            user_id=user_id,
+            item_id=item_id,
+            keyword_id=query.keyword_id,
+        ).one_or_none()
+        if feedback is None:
+            feedback = ItemRelevanceFeedback(
+                user_id=user_id,
+                item_id=item_id,
+                keyword_id=query.keyword_id,
+                required_keywords=query.required_keywords,
+                excluded_keywords=query.excluded_keywords,
+                created_at=datetime.now(timezone.utc),
+            )
+            self.session.add(feedback)
+
+        feedback.is_relevant = relevance_label
+        feedback.required_keywords = query.required_keywords
+        feedback.excluded_keywords = query.excluded_keywords
+        self.session.flush()
+        return RelevanceInteraction(
+            user_id=user_id,
+            search_id=str(search_id),
+            item_id=str(item_id),
+            interaction_type=interaction_type,
+            label=label,
+            source=source,
+            persisted=True,
+        )
+
+
+def _object_id(source: Any, *names: str) -> Any:
+    for name in names:
+        value = (
+            source.get(name)
+            if isinstance(source, dict)
+            else getattr(source, name, None)
+        )
+        if value is not None:
+            return value
+    return None
+
+
+def _keyword_id(saved_search: Any) -> Any:
+    keyword_id = _object_id(saved_search, "keyword_id")
+    if keyword_id is not None:
+        return keyword_id
+    keyword = (
+        saved_search.get("keyword")
+        if isinstance(saved_search, dict)
+        else getattr(
+            saved_search,
+            "keyword",
+            None,
+        )
+    )
+    return _object_id(keyword, "keyword_id", "id") if keyword is not None else None
+
+
+def _label_to_bool(label: str | None) -> bool | None:
+    if label is None:
+        return None
+    normalized = label.strip().lower()
+    if normalized in {"relevant", "positive", "true", "yes", "1"}:
+        return True
+    if normalized in {"irrelevant", "negative", "false", "no", "0"}:
+        return False
+    return None

--- a/app/relevance/scoring.py
+++ b/app/relevance/scoring.py
@@ -1,59 +1,75 @@
-from dataclasses import dataclass
-import re
+from typing import Any, Protocol
 
-from app.utils.text_helpers import remove_accents
-
-
-ACCESSORY_TERMS = {
-    "case",
-    "cases",
-    "cover",
-    "covers",
-    "protector",
-    "screen",
-    "charger",
-    "cable",
-    "mount",
-    "holder",
-}
+from app.relevance.domain import RelevanceDecision
+from app.relevance.features import extract_item_features, terms
 
 
-@dataclass(frozen=True)
-class RelevanceDecision:
-    score: float
-    should_notify: bool
-    reasons: tuple = ()
+class RelevanceScorer(Protocol):
+    """Inference contract for baseline or trained relevance scorers."""
+
+    def score_features(self, features: dict[str, Any]) -> RelevanceDecision:
+        """Score extracted features and return a notification decision."""
 
 
 class BaselineRelevanceScorer:
     """Small rules baseline that can later be replaced by a trained model."""
 
-    def score(self, query_text, item):
-        query_terms = _terms(query_text)
-        title_terms = _terms(getattr(item, "title", None) or item.get("title", ""))
+    threshold = 0.5
 
+    def score(self, query_text: str, item: Any) -> RelevanceDecision:
+        """Compatibility API for callers that score a query and item directly."""
+
+        title = getattr(item, "title", None)
+        if title is None and isinstance(item, dict):
+            title = item.get("title", "")
+        query_terms = terms(query_text)
+        title_terms = terms(str(title or ""))
+        query_match_ratio = 0.5
+        if query_terms:
+            query_match_ratio = len(query_terms & title_terms) / len(query_terms)
+
+        features: dict[str, Any] = {
+            "query_terms": query_terms,
+            "title_terms": title_terms,
+            "query_match_ratio": query_match_ratio,
+            "query_term_match_count": len(query_terms & title_terms),
+            "accessory_terms_present": False,
+            "query_has_accessory_terms": False,
+        }
+        return self.score_features(features)
+
+    def score_search_item(self, saved_search: Any, item: Any) -> RelevanceDecision:
+        """Score an item after extracting saved-search aware features."""
+
+        return self.score_features(extract_item_features(saved_search, item))
+
+    def score_features(self, features: dict[str, Any]) -> RelevanceDecision:
+        """Score precomputed relevance features without side effects."""
+
+        query_terms = features.get("query_terms") or set()
+        score = float(features.get("query_match_ratio") or 0.0)
+        reasons: list[str] = []
         if not query_terms:
-            return RelevanceDecision(score=0.5, should_notify=True, reasons=("empty_query",))
+            return RelevanceDecision(
+                score=0.5,
+                should_notify=True,
+                reasons=("empty_query",),
+                features=features,
+            )
 
-        matched_terms = query_terms & title_terms
-        score = len(matched_terms) / len(query_terms)
-        reasons = []
-
-        if matched_terms:
+        if features.get("query_term_match_count", 0) > 0 or score > 0:
             reasons.append("query_terms_matched")
 
-        if ACCESSORY_TERMS & title_terms and not ACCESSORY_TERMS & query_terms:
+        if features.get("accessory_terms_present") and not features.get(
+            "query_has_accessory_terms"
+        ):
             score -= 0.35
             reasons.append("likely_accessory")
 
         score = max(0.0, min(1.0, score))
         return RelevanceDecision(
             score=score,
-            should_notify=score >= 0.5,
+            should_notify=score >= self.threshold,
             reasons=tuple(reasons),
+            features=features,
         )
-
-
-def _terms(text):
-    normalised = remove_accents((text or "").lower())
-    return set(re.findall(r"[a-z0-9]+", normalised))

--- a/app/relevance/service.py
+++ b/app/relevance/service.py
@@ -1,0 +1,143 @@
+from typing import Any
+
+from app.relevance.domain import RelevanceDecision
+from app.relevance.features import extract_item_features
+from app.relevance.repository import RelevanceRepository, SqlAlchemyRelevanceRepository
+from app.relevance.scoring import BaselineRelevanceScorer, RelevanceScorer
+
+
+class RelevanceService:
+    """Facade for feature extraction, feedback capture, and relevance decisions."""
+
+    def __init__(
+        self,
+        repository: RelevanceRepository | None = None,
+        scorer: RelevanceScorer | None = None,
+    ) -> None:
+        self.repository = repository or SqlAlchemyRelevanceRepository()
+        self.scorer = scorer or BaselineRelevanceScorer()
+
+    def extract_features(self, saved_search: Any, item: Any) -> dict[str, Any]:
+        """Extract model-ready features from a saved search and item."""
+
+        return extract_item_features(saved_search, item)
+
+    def record_interaction(
+        self,
+        user_id: int,
+        search_id: str,
+        item_id: str,
+        interaction_type: str,
+        label: str | None = None,
+        source: str | None = None,
+    ) -> object:
+        """Record an onboarding or result interaction through the repository."""
+
+        return self.repository.record_interaction(
+            user_id=user_id,
+            search_id=search_id,
+            item_id=item_id,
+            interaction_type=interaction_type,
+            label=label,
+            source=source,
+        )
+
+    def should_notify(
+        self,
+        user_id: int,
+        saved_search: Any,
+        item: Any,
+    ) -> RelevanceDecision:
+        """Compose hard filters, explicit feedback, and baseline score."""
+
+        features = self.extract_features(saved_search, item)
+        hard_filter_reasons = _hard_filter_failures(features)
+        if hard_filter_reasons:
+            return RelevanceDecision(
+                score=0.0,
+                should_notify=False,
+                reasons=tuple(hard_filter_reasons),
+                features=features,
+            )
+
+        feedback_decision = _feedback_decision(
+            self.repository.get_feedback(user_id, saved_search, item),
+            features,
+        )
+        if feedback_decision is not None:
+            return feedback_decision
+
+        return self.scorer.score_features(features)
+
+
+def _hard_filter_failures(features: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if not features["required_keywords_present"]:
+        failures.append("missing_required_keywords")
+    if features["excluded_keywords_present"]:
+        failures.append("excluded_keywords_present")
+    if not _price_matches(features):
+        failures.append("price_outside_range")
+    if not _condition_matches(features):
+        failures.append("condition_mismatch")
+    if not _location_matches(features):
+        failures.append("location_mismatch")
+    if not _buying_options_match(features):
+        failures.append("buying_options_mismatch")
+    return failures
+
+
+def _feedback_decision(
+    feedback: Any | None,
+    features: dict[str, Any],
+) -> RelevanceDecision | None:
+    if feedback is None or getattr(feedback, "is_relevant", None) is None:
+        return None
+    if feedback.is_relevant:
+        return RelevanceDecision(
+            score=1.0,
+            should_notify=True,
+            reasons=("user_marked_relevant",),
+            features=features,
+        )
+    return RelevanceDecision(
+        score=0.0,
+        should_notify=False,
+        reasons=("user_marked_irrelevant",),
+        features=features,
+    )
+
+
+def _price_matches(features: dict[str, Any]) -> bool:
+    price = features["price"]
+    if price is None:
+        return features["min_price"] is None and features["max_price"] is None
+    min_price = features["min_price"]
+    max_price = features["max_price"]
+    if min_price is not None and price < min_price:
+        return False
+    if max_price is not None and price > max_price:
+        return False
+    return True
+
+
+def _condition_matches(features: dict[str, Any]) -> bool:
+    expected = features["expected_condition"]
+    actual = features["condition"]
+    return expected is None or actual is None or actual == expected
+
+
+def _location_matches(features: dict[str, Any]) -> bool:
+    expected = features["expected_location"]
+    actual = features["location_country"]
+    if expected in (None, "ANY"):
+        return True
+    return actual is None or actual == expected
+
+
+def _buying_options_match(features: dict[str, Any]) -> bool:
+    expected = features["expected_buying_options"]
+    actual = features["buying_options"]
+    if expected in (None, "FIXED_PRICE|AUCTION"):
+        return True
+    return actual is None or expected in actual.split("|")

--- a/app/tests/test_relevance_service.py
+++ b/app/tests/test_relevance_service.py
@@ -1,0 +1,191 @@
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from app.relevance import RelevanceService
+
+
+@dataclass(frozen=True)
+class SearchFilters:
+    min_price: float | None = None
+    max_price: float | None = None
+    item_location: str | None = "GB"
+    condition: str | None = None
+    buying_options: str = "FIXED_PRICE|AUCTION"
+    required_keywords: str | None = None
+    excluded_keywords: str | None = None
+
+
+@dataclass(frozen=True)
+class SavedSearch:
+    id: str
+    user_id: int
+    keyword_id: int
+    keywords: str
+    marketplace: str
+    is_active: bool
+    filters: SearchFilters
+
+
+@dataclass(frozen=True)
+class Feedback:
+    is_relevant: bool | None
+
+
+class FakeRepository:
+    def __init__(self, feedback: Feedback | None = None) -> None:
+        self.feedback = feedback
+        self.recorded_interactions: list[dict[str, Any]] = []
+
+    def get_feedback(
+        self,
+        user_id: int,
+        saved_search: SavedSearch,
+        item: dict[str, Any],
+    ) -> Feedback | None:
+        return self.feedback
+
+    def record_interaction(
+        self,
+        user_id: int,
+        search_id: str,
+        item_id: str,
+        interaction_type: str,
+        label: str | None = None,
+        source: str | None = None,
+    ) -> object:
+        interaction = {
+            "user_id": user_id,
+            "search_id": search_id,
+            "item_id": item_id,
+            "interaction_type": interaction_type,
+            "label": label,
+            "source": source,
+        }
+        self.recorded_interactions.append(interaction)
+        return interaction
+
+
+def test_relevance_service_extracts_search_and_item_features() -> None:
+    service = RelevanceService(repository=FakeRepository())
+    saved_search = _saved_search(
+        required_keywords="charizard", excluded_keywords="proxy"
+    )
+    item = _item(title="Pokemon Charizard 1999 Holo", price="125.50")
+
+    features = service.extract_features(saved_search, item)
+
+    assert features["query_text"] == "pokemon charizard"
+    assert features["required_keywords_present"] is True
+    assert features["excluded_keywords_present"] is False
+    assert features["query_match_ratio"] == 1.0
+    assert features["price"] == Decimal("125.50")
+
+
+def test_relevance_service_keeps_required_keywords_as_hard_filter() -> None:
+    service = RelevanceService(repository=FakeRepository())
+    saved_search = _saved_search(required_keywords="charizard")
+    item = _item(title="Pokemon Blastoise Holo")
+
+    decision = service.should_notify(user_id=1, saved_search=saved_search, item=item)
+
+    assert decision.should_notify is False
+    assert decision.score == 0.0
+    assert decision.reasons == ("missing_required_keywords",)
+
+
+def test_relevance_service_keeps_excluded_keywords_as_hard_filter() -> None:
+    service = RelevanceService(repository=FakeRepository(Feedback(is_relevant=True)))
+    saved_search = _saved_search(excluded_keywords="proxy")
+    item = _item(title="Pokemon Charizard proxy card")
+
+    decision = service.should_notify(user_id=1, saved_search=saved_search, item=item)
+
+    assert decision.should_notify is False
+    assert decision.reasons == ("excluded_keywords_present",)
+
+
+def test_relevance_service_uses_explicit_irrelevant_feedback() -> None:
+    service = RelevanceService(repository=FakeRepository(Feedback(is_relevant=False)))
+    saved_search = _saved_search()
+    item = _item(title="Pokemon Charizard Holo")
+
+    decision = service.should_notify(user_id=1, saved_search=saved_search, item=item)
+
+    assert decision.should_notify is False
+    assert decision.score == 0.0
+    assert decision.reasons == ("user_marked_irrelevant",)
+
+
+def test_relevance_service_scores_matching_items_with_baseline_heuristic() -> None:
+    service = RelevanceService(repository=FakeRepository())
+    saved_search = _saved_search()
+    item = _item(title="Pokemon Charizard Holo")
+
+    decision = service.should_notify(user_id=1, saved_search=saved_search, item=item)
+
+    assert decision.should_notify is True
+    assert decision.score == 1.0
+    assert "query_terms_matched" in decision.reasons
+
+
+def test_relevance_service_penalizes_likely_accessory_items() -> None:
+    service = RelevanceService(repository=FakeRepository())
+    saved_search = _saved_search()
+    item = _item(title="Pokemon Charizard card case")
+
+    decision = service.should_notify(user_id=1, saved_search=saved_search, item=item)
+
+    assert decision.should_notify is True
+    assert decision.score == 0.65
+    assert "likely_accessory" in decision.reasons
+
+
+def test_relevance_service_records_interactions_through_repository() -> None:
+    repository = FakeRepository()
+    service = RelevanceService(repository=repository)
+
+    result = service.record_interaction(
+        user_id=1,
+        search_id="search-1",
+        item_id="item-1",
+        interaction_type="onboarding_label",
+        label="relevant",
+        source="preview",
+    )
+
+    assert result == repository.recorded_interactions[0]
+    assert repository.recorded_interactions[0]["label"] == "relevant"
+
+
+def _saved_search(
+    required_keywords: str | None = None,
+    excluded_keywords: str | None = None,
+) -> SavedSearch:
+    return SavedSearch(
+        id="search-1",
+        user_id=1,
+        keyword_id=10,
+        keywords="pokemon charizard",
+        marketplace="EBAY_GB",
+        is_active=True,
+        filters=SearchFilters(
+            min_price=10,
+            max_price=500,
+            item_location="GB",
+            condition="USED",
+            required_keywords=required_keywords,
+            excluded_keywords=excluded_keywords,
+        ),
+    )
+
+
+def _item(title: str, price: str = "100") -> dict[str, Any]:
+    return {
+        "item_id": "item-1",
+        "title": title,
+        "price": price,
+        "condition": "USED",
+        "location": {"country": "GB"},
+        "buying_options": "FIXED_PRICE",
+    }

--- a/app/tests/test_relevance_service.py
+++ b/app/tests/test_relevance_service.py
@@ -1,8 +1,12 @@
 from dataclasses import dataclass
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any
 
 from app.relevance import RelevanceService
+from app.relevance.domain import RelevanceInteraction
+from app.relevance.repository import SqlAlchemyRelevanceRepository
+import app.relevance.repository as relevance_repository
 
 
 @dataclass(frozen=True)
@@ -158,6 +162,87 @@ def test_relevance_service_records_interactions_through_repository() -> None:
     assert repository.recorded_interactions[0]["label"] == "relevant"
 
 
+def test_non_bool_onboarding_label_persists_through_interaction_repository() -> None:
+    interaction_repository = FakeInteractionRepository()
+    repository = SqlAlchemyRelevanceRepository(
+        session=FakeSession(),
+        interaction_repository=interaction_repository,
+    )
+
+    result = repository.record_interaction(
+        user_id=1,
+        search_id="search-1",
+        item_id="item-1",
+        interaction_type="onboarding_label",
+        label="maybe",
+        source="preview",
+    )
+
+    assert isinstance(result, RelevanceInteraction)
+    assert result.persisted is True
+    assert interaction_repository.recorded_payloads == [
+        {
+            "user_id": 1,
+            "query_id": "search-1",
+            "item_id": "item-1",
+            "interaction_type": "onboarding_label",
+            "label": "maybe",
+            "source": "preview",
+            "metadata_json": {"search_id": "search-1"},
+        }
+    ]
+
+
+def test_legacy_feedback_fallback_still_persists_bool_label(monkeypatch) -> None:
+    session = FakeSession()
+    query = SimpleNamespace(
+        keyword_id=10,
+        required_keywords="charizard",
+        excluded_keywords="proxy",
+    )
+    feedback_lookup = FakeLookup(result=None)
+    monkeypatch.setattr(
+        relevance_repository,
+        "UserQuery",
+        SimpleNamespace(query=FakeLookup(result=query)),
+    )
+    monkeypatch.setattr(
+        relevance_repository,
+        "ItemRelevanceFeedback",
+        FakeFeedbackModel(feedback_lookup),
+    )
+
+    repository = SqlAlchemyRelevanceRepository(session=session)
+
+    result = repository.record_interaction(
+        user_id=1,
+        search_id="search-1",
+        item_id="item-1",
+        interaction_type="onboarding_label",
+        label="relevant",
+        source="preview",
+    )
+
+    assert isinstance(result, RelevanceInteraction)
+    assert result.persisted is True
+    assert session.flush_count == 1
+    assert len(session.added) == 1
+    assert session.added[0].is_relevant is True
+    assert session.added[0].required_keywords == "charizard"
+    assert session.added[0].excluded_keywords == "proxy"
+
+
+def test_should_notify_behavior_is_unchanged_by_interaction_support() -> None:
+    service = RelevanceService(repository=FakeRepository(Feedback(is_relevant=False)))
+    saved_search = _saved_search()
+    item = _item(title="Pokemon Charizard Holo")
+
+    decision = service.should_notify(user_id=1, saved_search=saved_search, item=item)
+
+    assert decision.should_notify is False
+    assert decision.reasons == ("user_marked_irrelevant",)
+
+
 def _saved_search(
     required_keywords: str | None = None,
     excluded_keywords: str | None = None,
@@ -189,3 +274,52 @@ def _item(title: str, price: str = "100") -> dict[str, Any]:
         "location": {"country": "GB"},
         "buying_options": "FIXED_PRICE",
     }
+
+
+class FakeInteractionRepository:
+    def __init__(self) -> None:
+        self.recorded_payloads: list[dict[str, Any]] = []
+
+    def values(self, **payload: Any) -> dict[str, Any]:
+        return payload
+
+    def add(self, payload: dict[str, Any]) -> object:
+        self.recorded_payloads.append(payload)
+        return payload
+
+    def record_interaction(self, **payload: Any) -> object:
+        self.recorded_payloads.append(payload)
+        return payload
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.added: list[Any] = []
+        self.flush_count = 0
+
+    def add(self, value: Any) -> None:
+        self.added.append(value)
+
+    def flush(self) -> None:
+        self.flush_count += 1
+
+
+class FakeLookup:
+    def __init__(self, result: Any) -> None:
+        self.result = result
+        self.filters: dict[str, Any] | None = None
+
+    def filter_by(self, **filters: Any) -> "FakeLookup":
+        self.filters = filters
+        return self
+
+    def one_or_none(self) -> Any:
+        return self.result
+
+
+class FakeFeedbackModel:
+    def __init__(self, query: FakeLookup) -> None:
+        self.query = query
+
+    def __call__(self, **kwargs: Any) -> Any:
+        return SimpleNamespace(**kwargs)


### PR DESCRIPTION
Closes #20

## Summary
- Adds a relevance foundation with `RelevanceDecision`, `RelevanceInteraction`, feature extraction, baseline scorer protocol, and `RelevanceService`.
- Preserves legacy `required_keywords` and `excluded_keywords` as hard filters before feedback/scoring.
- Adds injectable repository/scorer interfaces plus a SQLAlchemy adapter that reuses the existing feedback table for labeled interactions.
- Adds focused unit tests for feature extraction, hard filters, explicit feedback, heuristic scoring, and interaction recording.

## Validation
- `venv/bin/pytest app/tests/test_relevance_service.py` - passed, 7 tests.
- `venv/bin/python -m compileall app ebay_client config.py` - passed.
- `venv/bin/pytest` - failed during collection on pre-existing unrelated test issues: removed/missing symbols `Query`, `archive_items`, `load_historical_items`, `cancel_subscription_logic`, `db_session`, and missing `ENCRYPTION_KEY`.
- `venv/bin/mypy .` - failed on pre-existing project/stub issues and stale test references; no relevance-specific issues found with `venv/bin/mypy app/relevance app/tests/test_relevance_service.py --follow-imports=skip`.
- `venv/bin/black app/relevance app/tests/test_relevance_service.py` - passed. I did not run destructive `black .` because `black --check .` reports 59 out-of-scope files would be modified, including `ebay_client/**` and `app/models.py`, which this task explicitly forbids editing.

## Notes
- No migrations added.
- `ebay_client/**`, models, repositories, searches, routes, notifications, and jobs were not edited.
