### PR TITLE
[codex] Route saved searches through domain helpers

### DIFF
--- a/app/routes/queries.py
+++ b/app/routes/queries.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import datetime, timezone
-from decimal import Decimal
 from typing import Any
 
 from flask import (
@@ -31,6 +29,7 @@ from app.models import (
 )
 from app.relevance import RelevanceFeedbackService
 from app.repositories import ItemRepository
+from app.searches import SavedSearch, saved_search_from_model
 from app.utils.graph_helpers import get_price_data
 from app.utils.price_helpers import remove_price_outliers
 from app.utils.query_helpers import update_user_usage
@@ -39,95 +38,6 @@ from app.utils.text_helpers import item_matches_keywords
 bp = Blueprint("queries", __name__, url_prefix="/queries")
 
 VALID_FEEDBACK = {"relevant", "irrelevant"}
-
-
-@dataclass(frozen=True)
-class SearchFilters:
-    """Route-facing filter snapshot for saved-search service calls."""
-
-    min_price: Decimal | None
-    max_price: Decimal | None
-    item_location: str | None
-    condition: str | None
-    buying_options: str | None
-    required_keywords: str
-    excluded_keywords: str
-
-
-@dataclass(frozen=True)
-class SearchSchedule:
-    """Route-facing schedule snapshot for saved-search service calls."""
-
-    check_interval: int
-    first_run: bool
-    last_full_run: datetime | None
-    next_full_run: datetime | None
-    last_recent_run: datetime | None
-
-
-@dataclass(frozen=True)
-class SavedSearch:
-    """Route-facing saved-search snapshot detached from SQLAlchemy."""
-
-    id: Any
-    user_id: int
-    keyword_id: int
-    keywords: str
-    marketplace: str
-    is_active: bool
-    filters: SearchFilters
-    schedule: SearchSchedule
-
-
-def saved_search_from_model(user_query: UserQuery) -> SavedSearch:
-    """Create a saved-search snapshot from the current database model."""
-
-    keyword_text = user_query.keyword.keyword_text if user_query.keyword else ""
-    return SavedSearch(
-        id=user_query.query_id,
-        user_id=user_query.user_id,
-        keyword_id=user_query.keyword_id,
-        keywords=keyword_text,
-        marketplace=user_query.marketplace,
-        is_active=user_query.is_active,
-        filters=SearchFilters(
-            min_price=user_query.min_price,
-            max_price=user_query.max_price,
-            item_location=_query_location_filter(user_query.item_location),
-            condition=_optional_text(user_query.condition),
-            buying_options=_optional_text(user_query.buying_options),
-            required_keywords=_text_value(user_query.required_keywords),
-            excluded_keywords=_text_value(user_query.excluded_keywords),
-        ),
-        schedule=SearchSchedule(
-            check_interval=user_query.check_interval,
-            first_run=bool(user_query.first_run),
-            last_full_run=user_query.last_full_run,
-            next_full_run=user_query.next_full_run,
-            last_recent_run=user_query.last_recent_run,
-        ),
-    )
-
-
-def to_ebay_search_params(saved_search: SavedSearch) -> dict[str, Any]:
-    """Map a saved search into executor/search-client parameters."""
-
-    filters = {
-        "min_price": saved_search.filters.min_price,
-        "max_price": saved_search.filters.max_price,
-        "item_location": saved_search.filters.item_location,
-        "condition": saved_search.filters.condition,
-        "buying_options": saved_search.filters.buying_options,
-    }
-    return {
-        "keywords": saved_search.keywords,
-        "marketplace": saved_search.marketplace,
-        "filters": {
-            key: value for key, value in filters.items() if value not in (None, "")
-        },
-        "required_keywords": saved_search.filters.required_keywords,
-        "excluded_keywords": saved_search.filters.excluded_keywords,
-    }
 
 
 @bp.route("/manage")
@@ -466,10 +376,9 @@ def _historical_items_for_search(
         )
     )
 
-    if saved_search.filters.item_location is not None:
-        query = query.filter(
-            Item.location_country == saved_search.filters.item_location
-        )
+    location = _saved_search_location_filter(saved_search)
+    if location is not None:
+        query = query.filter(Item.location_country == location)
 
     if excluded_item_ids is not None:
         query = query.filter(~Item.item_id.in_(excluded_item_ids))
@@ -480,7 +389,7 @@ def _historical_items_for_search(
 
 
 def _item_matches_saved_search(item: Item, saved_search: SavedSearch) -> bool:
-    location = saved_search.filters.item_location
+    location = _saved_search_location_filter(saved_search)
     if location is not None and item.location_country != location:
         return False
 
@@ -489,9 +398,14 @@ def _item_matches_saved_search(item: Item, saved_search: SavedSearch) -> bool:
 
     return item_matches_keywords(
         item,
-        saved_search.filters.required_keywords,
-        saved_search.filters.excluded_keywords,
+        _text_value(saved_search.filters.required_keywords),
+        _text_value(saved_search.filters.excluded_keywords),
     )
+
+
+def _saved_search_location_filter(saved_search: SavedSearch) -> str | None:
+    item_location = saved_search.filters.item_location
+    return None if item_location in (None, "", "any") else item_location
 
 
 def _feedback_blocks_item(user_id: int, keyword_id: int, item_id: int) -> bool:
@@ -587,14 +501,6 @@ def _add_usage_or_raise(check_interval: int) -> None:
 def _remove_usage_if_needed(check_interval: int | None) -> None:
     if check_interval is not None:
         update_user_usage(current_user, check_interval, "remove")
-
-
-def _query_location_filter(item_location: str | None) -> str | None:
-    return None if item_location in (None, "", "any") else item_location
-
-
-def _optional_text(value: str | None) -> str | None:
-    return value or None
 
 
 def _text_value(value: str | None) -> str:

--- a/app/routes/queries.py
+++ b/app/routes/queries.py
@@ -1,419 +1,279 @@
-from flask import Blueprint, jsonify, render_template, redirect, url_for, request, flash, abort
-from flask_login import login_required, current_user
-from sqlalchemy import exists, func, select
-from app.models import ItemRelevanceFeedback, Keyword, KeywordItems, UserQuery, UserQueryItems, db, Item, copy_item
-from app.forms import QueryForm, DeleteForm  # Create this form if needed
-from flask import current_app
+from __future__ import annotations
+
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from flask import (
+    Blueprint,
+    abort,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from flask_login import current_user, login_required
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload
+
+from app.forms import DeleteForm, QueryForm
+from app.models import (
+    Item,
+    ItemRelevanceFeedback,
+    Keyword,
+    KeywordItems,
+    UserQuery,
+    UserQueryItems,
+    db,
+)
+from app.relevance import RelevanceFeedbackService
+from app.repositories import ItemRepository
 from app.utils.graph_helpers import get_price_data
 from app.utils.price_helpers import remove_price_outliers
 from app.utils.query_helpers import update_user_usage
 from app.utils.text_helpers import item_matches_keywords
-from app.relevance import RelevanceFeedbackService
-import numpy as np
 
-bp = Blueprint('queries', __name__, url_prefix='/queries')
+bp = Blueprint("queries", __name__, url_prefix="/queries")
 
-@bp.route('/manage')
+VALID_FEEDBACK = {"relevant", "irrelevant"}
+
+
+@dataclass(frozen=True)
+class SearchFilters:
+    """Route-facing filter snapshot for saved-search service calls."""
+
+    min_price: Decimal | None
+    max_price: Decimal | None
+    item_location: str | None
+    condition: str | None
+    buying_options: str | None
+    required_keywords: str
+    excluded_keywords: str
+
+
+@dataclass(frozen=True)
+class SearchSchedule:
+    """Route-facing schedule snapshot for saved-search service calls."""
+
+    check_interval: int
+    first_run: bool
+    last_full_run: datetime | None
+    next_full_run: datetime | None
+    last_recent_run: datetime | None
+
+
+@dataclass(frozen=True)
+class SavedSearch:
+    """Route-facing saved-search snapshot detached from SQLAlchemy."""
+
+    id: Any
+    user_id: int
+    keyword_id: int
+    keywords: str
+    marketplace: str
+    is_active: bool
+    filters: SearchFilters
+    schedule: SearchSchedule
+
+
+def saved_search_from_model(user_query: UserQuery) -> SavedSearch:
+    """Create a saved-search snapshot from the current database model."""
+
+    keyword_text = user_query.keyword.keyword_text if user_query.keyword else ""
+    return SavedSearch(
+        id=user_query.query_id,
+        user_id=user_query.user_id,
+        keyword_id=user_query.keyword_id,
+        keywords=keyword_text,
+        marketplace=user_query.marketplace,
+        is_active=user_query.is_active,
+        filters=SearchFilters(
+            min_price=user_query.min_price,
+            max_price=user_query.max_price,
+            item_location=_query_location_filter(user_query.item_location),
+            condition=_optional_text(user_query.condition),
+            buying_options=_optional_text(user_query.buying_options),
+            required_keywords=_text_value(user_query.required_keywords),
+            excluded_keywords=_text_value(user_query.excluded_keywords),
+        ),
+        schedule=SearchSchedule(
+            check_interval=user_query.check_interval,
+            first_run=bool(user_query.first_run),
+            last_full_run=user_query.last_full_run,
+            next_full_run=user_query.next_full_run,
+            last_recent_run=user_query.last_recent_run,
+        ),
+    )
+
+
+def to_ebay_search_params(saved_search: SavedSearch) -> dict[str, Any]:
+    """Map a saved search into executor/search-client parameters."""
+
+    filters = {
+        "min_price": saved_search.filters.min_price,
+        "max_price": saved_search.filters.max_price,
+        "item_location": saved_search.filters.item_location,
+        "condition": saved_search.filters.condition,
+        "buying_options": saved_search.filters.buying_options,
+    }
+    return {
+        "keywords": saved_search.keywords,
+        "marketplace": saved_search.marketplace,
+        "filters": {
+            key: value for key, value in filters.items() if value not in (None, "")
+        },
+        "required_keywords": saved_search.filters.required_keywords,
+        "excluded_keywords": saved_search.filters.excluded_keywords,
+    }
+
+
+@bp.route("/manage")
 @login_required
 def manage_queries():
-    print("Current user:", current_user)
-    queries = UserQuery.query.options(db.joinedload(UserQuery.keyword))\
-        .filter(UserQuery.user_id == current_user.id)\
-        .order_by(UserQuery.created_at.desc())\
+    queries = (
+        UserQuery.query.options(joinedload(UserQuery.keyword))
+        .filter(UserQuery.user_id == current_user.id)
+        .order_by(UserQuery.created_at.desc())
         .all()
-    print("Queries found:", queries)
+    )
     total_queries = len(queries)
-    active_queries = len([query for query in queries if query.is_active])
-    all_active = active_queries == total_queries
-    delete_form = DeleteForm()
-    return render_template('queries/manage.html', queries=queries, delete_form=delete_form, all_active=all_active)
+    active_queries = sum(1 for query in queries if query.is_active)
+    return render_template(
+        "queries/manage.html",
+        queries=queries,
+        delete_form=DeleteForm(),
+        all_active=active_queries == total_queries,
+    )
 
-@bp.route('/edit_query/<string:query_id>', methods=['GET', 'POST'])
-def edit_query(query_id):
-    # Authentication check
-    if not current_user.is_authenticated:
-        flash('You need to be logged in to perform this action.', 'danger')
-        return redirect(url_for('auth.login'))
-    
-    # Fetch query with ownership check
-    user_query = UserQuery.query.get_or_404(query_id)
-    if user_query.user_id != current_user.id:
-        abort(403)
 
+@bp.route("/edit_query/<string:query_id>", methods=["GET", "POST"])
+def edit_query(query_id: str):
+    auth_redirect = _require_authenticated_user()
+    if auth_redirect:
+        return auth_redirect
+
+    user_query = _get_owned_query_or_403(query_id)
     form = QueryForm(obj=user_query)
-    
-    # Pre-fill keyword if needed
-    if request.method == 'GET':
+
+    if request.method == "GET":
         form.keywords.data = user_query.keyword.keyword_text
 
-    if form.validate_on_submit():
-        try:
-
-            if form.marketplace.data != user_query.marketplace:
-                # Prevent duplicate queries
-                existing_query = UserQuery.query.filter(
-                    UserQuery.user_id == current_user.id,
-                UserQuery.keyword_id == user_query.keyword_id,
-                UserQuery.item_location == form.item_location.data,
-                UserQuery.marketplace == form.marketplace.data
-            ).first()
-                
-                if existing_query:
-                    flash('You already have a query with this keyword and marketplace', 'danger')
-                    return render_template('queries/edit.html', form=form, query=user_query)
-            
-            old_interval = user_query.check_interval
-            new_interval = form.check_interval.data
-            
-            # Handle usage updates for interval changes
-            if old_interval != new_interval:
-                # Remove old usage
-                if not update_user_usage(current_user, old_interval, 'remove'):
-                    raise ValueError("Could not remove old interval usage")
-                
-                # Add new usage
-                if not update_user_usage(current_user, new_interval, 'add'):
-                    # Rollback usage change if limit exceeded
-                    update_user_usage(current_user, old_interval, 'add')
-                    raise ValueError("This interval would exceed your daily limit")
-    
-        
-            if form.required_keywords.data != user_query.required_keywords or form.excluded_keywords.data != user_query.excluded_keywords or user_query.item_location != form.item_location.data or user_query.marketplace != form.marketplace.data:
-                print("Required keywords or excluded keywords or item location changed or marketplace changed")
-                new_location = form.item_location.data
-                new_marketplace = form.marketplace.data
-                print("New location:", (new_location))
-                print("New marketplace:", (new_marketplace))
-                if new_location == 'any':
-                    new_location = None
-                # 1. Remove non-matching items and items that don't match new location specified in the query
-                query_items = UserQueryItems.query.filter_by(query_id=query_id).all()
-                print("Query items currently in query:", len(query_items))
-                deletions = [
-                    qi for qi in query_items
-                    if (
-                        not item_matches_keywords(qi.item, form.required_keywords.data, form.excluded_keywords.data)
-                        or (new_location is not None and qi.item.location_country != new_location)
-                        or qi.item.marketplace != new_marketplace
-                    )
-                ]
-                print("Deletions:", len(deletions))
-                # 2. Find new items to add (that match both keyword and new filters)
-                # Get the keyword_id from the user's original query
-                keyword_id = user_query.keyword_id
-
-                # Get existing item IDs as subquery
-                existing_items_subquery = select(UserQueryItems.item_id)\
-                    .where(UserQueryItems.query_id == query_id)\
-                    .scalar_subquery()
-
-                
-                # Get items in keyword items that match the new filters, avoiding the ones already in the query
-                potential_items = db.session.query(Item)\
-                    .join(KeywordItems, Item.item_id == KeywordItems.item_id)\
-                    .join(UserQuery, KeywordItems.keyword_id == UserQuery.keyword_id)\
-                    .outerjoin(
-                        ItemRelevanceFeedback,
-                        (ItemRelevanceFeedback.item_id == Item.item_id) &
-                        (ItemRelevanceFeedback.user_id == current_user.id) &
-                        (ItemRelevanceFeedback.keyword_id == keyword_id)
-                    )\
-                    .filter(
-                        KeywordItems.keyword_id == keyword_id,
-                        # Conditionally add location filter
-                        *([Item.location_country == new_location] if new_location is not None else []),
-                        Item.marketplace == new_marketplace,
-                        ~Item.item_id.in_(existing_items_subquery),
-                        db.or_(
-                            ItemRelevanceFeedback.is_relevant.is_(None),
-                            ItemRelevanceFeedback.is_relevant.is_(True)
-                        )
-                    )\
-                    .all()
-                print(f"Potential items: {len(potential_items)}")
-
-                additions = [
-                    UserQueryItems(query_id=query_id, item_id=item.item_id)
-                    for item in potential_items
-                    if item_matches_keywords(
-                        item,
-                        form.required_keywords.data,
-                        form.excluded_keywords.data
-                    )
-                ]
-
-                # 3. Batch process changes
-                for qi in deletions:
-                    db.session.delete(qi)
-            
-                for qi in additions:
-                    db.session.add(qi)
-
-                db.session.commit()
-            
-            # Update query fields
-            form.populate_obj(user_query)
-            user_query.updated_at = datetime.now(timezone.utc)
-            
-            db.session.commit()
-            flash('Query updated successfully', 'success')
-            return redirect(url_for('queries.manage_queries'))
-            
-        except Exception as e:
-            db.session.rollback()
-            current_app.logger.error(f"Query update failed: {str(e)}")
-            flash(f'Error updating query: {str(e)}', 'danger')
-
-    return render_template('queries/edit.html', form=form, query=user_query)
-
-@bp.route('/delete_query/<string:query_id>', methods=['POST'])
-def delete_query(query_id):
-    # Authentication check
-    if not current_user.is_authenticated:
-        flash('You need to be logged in to perform this action.', 'danger')
-        return redirect(url_for('auth.login'))
-    
-    # Fetch query with ownership check
-    user_query = UserQuery.query.get_or_404(query_id)
-    if user_query.user_id != current_user.id:
-        abort(403)
+    if not form.validate_on_submit():
+        return render_template("queries/edit.html", form=form, query=user_query)
 
     try:
-        # Store interval for usage update
-        old_interval = user_query.check_interval
-        
-        # Delete associations and query
-        UserQueryItems.query.filter_by(query_id=query_id).delete()
-        db.session.delete(user_query)
-        
-        # Update user usage before commit
-        if not update_user_usage(current_user, old_interval, 'remove'):
-            raise ValueError("Usage update failed during deletion")
-            
-        db.session.commit()
-        flash('Query deleted successfully', 'success')
-        
-    except Exception as e:
+        _update_saved_search(user_query, form)
+    except ValueError as exc:
+        flash(str(exc), "danger")
+        return render_template("queries/edit.html", form=form, query=user_query)
+    except Exception as exc:
         db.session.rollback()
-        current_app.logger.error(f"Query deletion failed: {str(e)}")
-        flash(f'Error deleting query: {str(e)}', 'danger')
+        current_app.logger.error("Query update failed: %s", exc)
+        flash(f"Error updating query: {exc}", "danger")
+        return render_template("queries/edit.html", form=form, query=user_query)
 
-    return redirect(url_for('queries.manage_queries'))
+    flash("Query updated successfully", "success")
+    return redirect(url_for("queries.manage_queries"))
 
-@bp.route('/create_query', methods=['GET', 'POST'])
-def create_query():
-    print("Current user authenticated:", current_user.is_authenticated)
-    form = QueryForm()
-    if request.method == 'GET':
-        form.check_interval.data = 5  # Default to 5 minutes
-    if form.validate_on_submit():
-        try:
-            
-            try:
-                if not update_user_usage(current_user, form.check_interval.data, 'add'):
-                    print("Current user query usage: ", current_user.query_usage)
-                    print("Current user tier: ", current_user.tier)
-                    flash('This query would exceed your daily limit', 'danger')
-                    return render_template('queries/create.html', form=form)
-                
-            except ValueError as e:
-                db.session.rollback()
-                flash(str(e), 'danger')
-                return render_template('queries/create.html', form=form)
-            
-            # Check if keyword exists (case-insensitive)
-            existing = Keyword.query.filter(
-                db.func.lower(Keyword.keyword_text) == db.func.lower(form.keywords.data.strip())
-            ).first()
-            
-            keyword_id = None
-            if form.keywords.data.strip():  # Prevent empty strings
-                if not existing:
-                    new_keyword = Keyword(keyword_text=form.keywords.data.strip())
-                    db.session.add(new_keyword)
-                    db.session.commit()  # Need to commit to get the ID
-                    keyword_id = new_keyword.keyword_id
-                else:
-                    keyword_id = existing.keyword_id
-                
-                # Prevent duplicate queries
-                existing_query = UserQuery.query.filter(
-                    UserQuery.user_id == current_user.id,
-                    UserQuery.keyword_id == keyword_id,
-                    UserQuery.item_location == form.item_location.data,
-                    UserQuery.marketplace == form.marketplace.data
-                ).first()
-                
-                if existing_query:
-                    flash('You already have a query with this keyword and marketplace', 'danger')
-                    print("Rolling back user usage")
-                    print("Current user query usage: ", current_user.query_usage)
-                    print("form.check_interval.data: ", form.check_interval.data)
-                    update_user_usage(current_user, form.check_interval.data, 'remove')
-                    return render_template('queries/create.html', form=form)
-        
-                
-                else: # Proceed with query creation
-                    new_user_query = UserQuery()
-                    form.populate_obj(new_user_query)
-                    new_user_query.user_id = current_user.id
-                    new_user_query.keyword_id = keyword_id
-                    new_user_query.created_at = datetime.now(timezone.utc)
-                    new_user_query.is_active = True
-                
-                    db.session.add(new_user_query)
-                    db.session.commit()
-            
-            #Load historical data if exists
-            target_country = new_user_query.item_location
-            target_marketplace = new_user_query.marketplace
-            # Filter historical items by country and marketplace
-            print("Target country:", target_country)
-            print("Target marketplace:", target_marketplace)
 
-            historical_items = (
-            KeywordItems.query
-            .join(Item, KeywordItems.item_id == Item.item_id)
-            .filter(
-                KeywordItems.keyword_id == keyword_id,
-                    Item.location_country == target_country,
-                    Item.marketplace == target_marketplace
-                )
-                    .all()
-            )
-            print("Historical items:", len(historical_items))
+@bp.route("/delete_query/<string:query_id>", methods=["POST"])
+def delete_query(query_id: str):
+    auth_redirect = _require_authenticated_user()
+    if auth_redirect:
+        return auth_redirect
 
-            filtered_historical_items = []
-            for item in historical_items:
-                if item_matches_keywords(
-                    item.item,
-                    form.required_keywords.data,
-                    form.excluded_keywords.data
-                ):
-                    filtered_historical_items.append(item)
+    user_query = _get_owned_query_or_403(query_id)
 
-            #fitler by required and excluded keywords
-            
-            count = 0
-            for keyword_item in filtered_historical_items:
-                feedback = ItemRelevanceFeedback.query.filter_by(user_id=current_user.id, item_id=keyword_item.item_id, keyword_id=keyword_id).first()
-                if feedback:
-                    if feedback.is_relevant == False:
-                        continue
-                # Create association unless the unless the user has marked the item as irrelevant
-                user_query_item = UserQueryItems(
-                    query_id=new_user_query.query_id,
-                    item_id=keyword_item.item_id,
-                    auction_ending_notification_sent=False
-                )
-                db.session.add(user_query_item)
-                count += 1
-            
-            if count > 0:
-                db.session.commit()
-                print(f"Loaded {count} historical items")
-            
-            return redirect(url_for('queries.manage_queries'))
-        except Exception as e:
-            db.session.rollback()
-            current_app.logger.error(f"Query creation failed: {str(e)}")
-            print("Rolling back user usage")
-            print("Current user query usage: ", current_user.query_usage)
-            print("form.check_interval.data: ", form.check_interval.data)
-            
-            update_user_usage(current_user, form.check_interval.data, 'remove')
-            flash('Error creating query: ' + str(e), 'danger')
+    try:
+        _delete_saved_search(user_query)
+    except Exception as exc:
+        db.session.rollback()
+        current_app.logger.error("Query deletion failed: %s", exc)
+        flash(f"Error deleting query: {exc}", "danger")
     else:
-        print("Form not validated. Errors:", form.errors)
-    return render_template('queries/create.html', form=form) 
+        flash("Query deleted successfully", "success")
 
-@bp.route('/queries/toggle_all', methods=['POST'])
+    return redirect(url_for("queries.manage_queries"))
+
+
+@bp.route("/create_query", methods=["GET", "POST"])
+def create_query():
+    auth_redirect = _require_authenticated_user()
+    if auth_redirect:
+        return auth_redirect
+
+    form = QueryForm()
+    if request.method == "GET":
+        form.check_interval.data = 5
+
+    if not form.validate_on_submit():
+        return render_template("queries/create.html", form=form)
+
+    try:
+        _create_saved_search(form)
+    except ValueError as exc:
+        flash(str(exc), "danger")
+        return render_template("queries/create.html", form=form)
+    except Exception as exc:
+        db.session.rollback()
+        current_app.logger.error("Query creation failed: %s", exc)
+        _remove_usage_if_needed(form.check_interval.data)
+        flash(f"Error creating query: {exc}", "danger")
+        return render_template("queries/create.html", form=form)
+
+    return redirect(url_for("queries.manage_queries"))
+
+
+@bp.route("/queries/toggle_all", methods=["POST"])
 @login_required
 def toggle_all_queries():
-    print("Toggling all queries")
-    new_state = not UserQuery.query.filter_by(user_id=current_user.id, is_active=True).count() > 0
-    for query in UserQuery.query.filter_by(user_id=current_user.id).all():
-        if query.is_active != new_state:
-            operation = 'add' if new_state else 'remove'
-            try:
-                update_user_usage(current_user, query.check_interval, operation)
-                query.is_active = new_state
-            except ValueError as e:
-                db.session.rollback()
-                flash(str(e), 'danger')
-                return redirect(url_for('queries.manage_queries'))
-    db.session.commit()
-    return redirect(url_for('queries.manage_queries'))
+    queries = UserQuery.query.filter_by(user_id=current_user.id).all()
+    new_state = not any(query.is_active for query in queries)
 
-@bp.route('/<string:query_id>/toggle', methods=['POST'])
-@login_required
-def toggle_query(query_id):
-    query = UserQuery.query.get_or_404(query_id)
-    if query.user_id != current_user.id:
-        abort(403)
-    
-    operation = 'remove' if query.is_active else 'add'
     try:
-        update_user_usage(current_user, query.check_interval, operation)
-        query.is_active = not query.is_active
+        for query in queries:
+            if query.is_active != new_state:
+                _set_query_active_state(query, new_state)
         db.session.commit()
-    except ValueError as e:
-        flash(str(e), 'danger')
-        return redirect(url_for('queries.manage_queries'))
-    
-    return redirect(url_for('queries.manage_queries'))
+    except ValueError as exc:
+        db.session.rollback()
+        flash(str(exc), "danger")
+
+    return redirect(url_for("queries.manage_queries"))
 
 
-@bp.route('/<string:query_id>')
+@bp.route("/<string:query_id>/toggle", methods=["POST"])
 @login_required
-def query_details(query_id):
-    print(f"Query ID: {query_id}")
-    query = UserQuery.query.filter_by(user_id=current_user.id, query_id=query_id).first_or_404()
-    
-    # Get ALL items for accurate stats
-    all_items = UserQueryItems.query\
-                         .filter_by(query_id=query_id)\
-                         .order_by(UserQueryItems.created_at.desc())\
-                         .all()
-    
+def toggle_query(query_id: str):
+    query = _get_owned_query_or_403(query_id)
 
-    # Remove outliers using IQR method
-    print("Length of all items:", len(all_items))
-    result = remove_price_outliers(all_items)
-    filtered_items = result[0] if result else []
-    auction_items = result[1] if len(result) > 1 else []
-    outliers = result[2] if len(result) > 2 else []
-    print("Length of filtered items:", len(filtered_items))
-    print("Length of auction items:", len(auction_items))
-    print("Length of outliers:", len(outliers) if outliers else "None")
-    # Calculate stats using filtered items
+    try:
+        _set_query_active_state(query, not query.is_active)
+        db.session.commit()
+    except ValueError as exc:
+        db.session.rollback()
+        flash(str(exc), "danger")
 
-    stats = {
-        'total_items': len(filtered_items+auction_items),
-    }
-    
-    # Only show first 100 items
-    #TODO: Make sure newest are first 
-    visible_items = filtered_items[:100]+auction_items[:100]
-    price_data, average_price_last_30_days, most_frequent_currency = get_price_data(filtered_items)
-
-    return render_template('queries/details.html', 
-                         query=query, 
-                         items=visible_items,
-                         auction_items=auction_items,
-                         stats=stats,
-                         price_data=price_data,
-                         average_price_last_30_days=average_price_last_30_days,
-                         most_frequent_currency=most_frequent_currency
-                         )
+    return redirect(url_for("queries.manage_queries"))
 
 
-@bp.route('/feedback/<string:query_id>/<int:item_id>', methods=['POST'])
+@bp.route("/<string:query_id>")
 @login_required
-def submit_feedback(query_id, item_id):
-    feedback = request.form.get('feedback')
-    if feedback not in ['relevant', 'irrelevant']:
+def query_details(query_id: str):
+    query = UserQuery.query.filter_by(
+        user_id=current_user.id, query_id=query_id
+    ).first_or_404()
+    return render_template("queries/details.html", **_query_details_context(query))
+
+
+@bp.route("/feedback/<string:query_id>/<int:item_id>", methods=["POST"])
+@login_required
+def submit_feedback(query_id: str, item_id: int):
+    feedback = request.form.get("feedback")
+    if feedback not in VALID_FEEDBACK:
         abort(400)
 
     user_query_item, allowed = RelevanceFeedbackService().record_item_feedback(
@@ -425,25 +285,317 @@ def submit_feedback(query_id, item_id):
     if not allowed:
         abort(403)
 
-    if feedback == 'irrelevant':
-        ordered_items = UserQueryItems.query.filter_by(query_id=query_id)\
-                            .order_by(UserQueryItems.created_at.asc()).all()
-        item_ids = [str(item.item_id) for item in ordered_items]
-        
-        try:
-            current_idx = item_ids.index(str(item_id))
-            prev_item_id = item_ids[current_idx - 1] if current_idx > 0 else None
-        except ValueError:
-            prev_item_id = None
-
+    if feedback == "irrelevant":
+        prev_item_id = _previous_item_id(query_id, item_id)
         db.session.delete(user_query_item)
         db.session.commit()
-
-        # Handle no previous item case
-        if not prev_item_id:
-            return redirect(url_for('queries.query_details', query_id=query_id))
-            
-        return redirect(url_for('queries.query_details', query_id=query_id) + f"#item-{prev_item_id}")
+        return _redirect_to_query_item(query_id, prev_item_id)
 
     db.session.commit()
-    return redirect(url_for('queries.query_details', query_id=query_id) + f"#item-{item_id}")
+    return _redirect_to_query_item(query_id, item_id)
+
+
+def _require_authenticated_user():
+    if current_user.is_authenticated:
+        return None
+
+    flash("You need to be logged in to perform this action.", "danger")
+    return redirect(url_for("auth.login"))
+
+
+def _get_owned_query_or_403(query_id: str) -> UserQuery:
+    user_query = UserQuery.query.get_or_404(query_id)
+    if user_query.user_id != current_user.id:
+        abort(403)
+    return user_query
+
+
+def _create_saved_search(form: QueryForm) -> UserQuery:
+    _add_usage_or_raise(form.check_interval.data)
+    keyword = _get_or_create_keyword(form.keywords.data)
+
+    if _find_duplicate_query(
+        keyword.keyword_id, form.item_location.data, form.marketplace.data
+    ):
+        _remove_usage_if_needed(form.check_interval.data)
+        raise ValueError("You already have a query with this keyword and marketplace")
+
+    user_query = UserQuery()
+    form.populate_obj(user_query)
+    user_query.user_id = current_user.id
+    user_query.keyword_id = keyword.keyword_id
+    user_query.keyword = keyword
+    user_query.created_at = datetime.now(timezone.utc)
+    user_query.is_active = True
+
+    db.session.add(user_query)
+    db.session.flush()
+    _load_historical_items(user_query)
+    db.session.commit()
+    return user_query
+
+
+def _update_saved_search(user_query: UserQuery, form: QueryForm) -> None:
+    if _identity_changed(user_query, form) and _find_duplicate_query(
+        user_query.keyword_id,
+        form.item_location.data,
+        form.marketplace.data,
+        exclude_query_id=user_query.query_id,
+    ):
+        raise ValueError("You already have a query with this keyword and marketplace")
+
+    _replace_usage_interval(user_query.check_interval, form.check_interval.data)
+
+    filters_changed = _filters_changed(user_query, form)
+    form.populate_obj(user_query)
+    user_query.updated_at = datetime.now(timezone.utc)
+
+    if filters_changed:
+        _sync_query_items_for_filters(user_query)
+
+    db.session.commit()
+
+
+def _delete_saved_search(user_query: UserQuery) -> None:
+    old_interval = user_query.check_interval
+    UserQueryItems.query.filter_by(query_id=user_query.query_id).delete()
+    db.session.delete(user_query)
+    _remove_usage_if_needed(old_interval)
+    db.session.commit()
+
+
+def _get_or_create_keyword(keyword_text: str) -> Keyword:
+    cleaned = keyword_text.strip()
+    keyword = Keyword.query.filter(
+        db.func.lower(Keyword.keyword_text) == db.func.lower(cleaned)
+    ).first()
+    if keyword:
+        return keyword
+
+    keyword = Keyword(keyword_text=cleaned)
+    db.session.add(keyword)
+    db.session.flush()
+    return keyword
+
+
+def _find_duplicate_query(
+    keyword_id: int,
+    item_location: str,
+    marketplace: str,
+    exclude_query_id: Any | None = None,
+) -> UserQuery | None:
+    query = UserQuery.query.filter(
+        UserQuery.user_id == current_user.id,
+        UserQuery.keyword_id == keyword_id,
+        UserQuery.item_location == item_location,
+        UserQuery.marketplace == marketplace,
+    )
+    if exclude_query_id is not None:
+        query = query.filter(UserQuery.query_id != exclude_query_id)
+    return query.first()
+
+
+def _identity_changed(user_query: UserQuery, form: QueryForm) -> bool:
+    return (
+        user_query.item_location != form.item_location.data
+        or user_query.marketplace != form.marketplace.data
+    )
+
+
+def _filters_changed(user_query: UserQuery, form: QueryForm) -> bool:
+    return (
+        _text_value(user_query.required_keywords)
+        != _text_value(form.required_keywords.data)
+        or _text_value(user_query.excluded_keywords)
+        != _text_value(form.excluded_keywords.data)
+        or user_query.item_location != form.item_location.data
+        or user_query.marketplace != form.marketplace.data
+    )
+
+
+def _load_historical_items(user_query: UserQuery) -> int:
+    saved_search = saved_search_from_model(user_query)
+    repository = ItemRepository()
+    linked_count = 0
+
+    for item in _historical_items_for_search(saved_search):
+        if _feedback_blocks_item(
+            user_query.user_id, user_query.keyword_id, item.item_id
+        ):
+            continue
+
+        if repository.link_query(user_query.query_id, item.item_id):
+            linked_count += 1
+
+    return linked_count
+
+
+def _sync_query_items_for_filters(user_query: UserQuery) -> None:
+    saved_search = saved_search_from_model(user_query)
+    existing_item_ids = select(UserQueryItems.item_id).where(
+        UserQueryItems.query_id == user_query.query_id
+    )
+
+    for query_item in UserQueryItems.query.filter_by(
+        query_id=user_query.query_id
+    ).all():
+        if not _item_matches_saved_search(query_item.item, saved_search):
+            db.session.delete(query_item)
+
+    repository = ItemRepository()
+    for item in _historical_items_for_search(
+        saved_search, excluded_item_ids=existing_item_ids
+    ):
+        if _feedback_blocks_item(
+            user_query.user_id, user_query.keyword_id, item.item_id
+        ):
+            continue
+        repository.link_query(user_query.query_id, item.item_id)
+
+
+def _historical_items_for_search(
+    saved_search: SavedSearch,
+    excluded_item_ids: Any | None = None,
+) -> list[Item]:
+    query = (
+        db.session.query(Item)
+        .join(KeywordItems, Item.item_id == KeywordItems.item_id)
+        .filter(
+            KeywordItems.keyword_id == saved_search.keyword_id,
+            Item.marketplace == saved_search.marketplace,
+        )
+    )
+
+    if saved_search.filters.item_location is not None:
+        query = query.filter(
+            Item.location_country == saved_search.filters.item_location
+        )
+
+    if excluded_item_ids is not None:
+        query = query.filter(~Item.item_id.in_(excluded_item_ids))
+
+    return [
+        item for item in query.all() if _item_matches_saved_search(item, saved_search)
+    ]
+
+
+def _item_matches_saved_search(item: Item, saved_search: SavedSearch) -> bool:
+    location = saved_search.filters.item_location
+    if location is not None and item.location_country != location:
+        return False
+
+    if item.marketplace != saved_search.marketplace:
+        return False
+
+    return item_matches_keywords(
+        item,
+        saved_search.filters.required_keywords,
+        saved_search.filters.excluded_keywords,
+    )
+
+
+def _feedback_blocks_item(user_id: int, keyword_id: int, item_id: int) -> bool:
+    feedback = ItemRelevanceFeedback.query.filter_by(
+        user_id=user_id,
+        item_id=item_id,
+        keyword_id=keyword_id,
+    ).first()
+    return bool(feedback and feedback.is_relevant is False)
+
+
+def _query_details_context(query: UserQuery) -> dict[str, Any]:
+    all_items = (
+        UserQueryItems.query.filter_by(query_id=query.query_id)
+        .order_by(UserQueryItems.created_at.desc())
+        .all()
+    )
+    filtered_items, auction_items, _outliers = _split_price_filtered_items(all_items)
+    visible_items = filtered_items[:100] + auction_items[:100]
+    price_data, average_price_last_30_days, most_frequent_currency = get_price_data(
+        filtered_items
+    )
+
+    return {
+        "query": query,
+        "items": visible_items,
+        "auction_items": auction_items,
+        "stats": {"total_items": len(filtered_items + auction_items)},
+        "price_data": price_data,
+        "average_price_last_30_days": average_price_last_30_days,
+        "most_frequent_currency": most_frequent_currency,
+    }
+
+
+def _split_price_filtered_items(
+    items: list[UserQueryItems],
+) -> tuple[list[UserQueryItems], list[UserQueryItems], list[UserQueryItems]]:
+    result = remove_price_outliers(items)
+    if not result:
+        return [], [], []
+
+    filtered_items = result[0]
+    auction_items = result[1] if len(result) > 1 else []
+    outliers = result[2] if len(result) > 2 else []
+    return filtered_items, auction_items, outliers
+
+
+def _previous_item_id(query_id: str, item_id: int) -> int | None:
+    ordered_items = (
+        UserQueryItems.query.filter_by(query_id=query_id)
+        .order_by(UserQueryItems.created_at.asc())
+        .all()
+    )
+    item_ids = [item.item_id for item in ordered_items]
+
+    try:
+        current_idx = item_ids.index(item_id)
+    except ValueError:
+        return None
+
+    return item_ids[current_idx - 1] if current_idx > 0 else None
+
+
+def _redirect_to_query_item(query_id: str, item_id: int | None):
+    details_url = url_for("queries.query_details", query_id=query_id)
+    if item_id is None:
+        return redirect(details_url)
+    return redirect(f"{details_url}#item-{item_id}")
+
+
+def _set_query_active_state(query: UserQuery, is_active: bool) -> None:
+    operation = "add" if is_active else "remove"
+    update_user_usage(current_user, query.check_interval, operation)
+    query.is_active = is_active
+
+
+def _replace_usage_interval(old_interval: int, new_interval: int) -> None:
+    if old_interval == new_interval:
+        return
+
+    _remove_usage_if_needed(old_interval)
+    try:
+        _add_usage_or_raise(new_interval)
+    except ValueError:
+        _add_usage_or_raise(old_interval)
+        raise
+
+
+def _add_usage_or_raise(check_interval: int) -> None:
+    update_user_usage(current_user, check_interval, "add")
+
+
+def _remove_usage_if_needed(check_interval: int | None) -> None:
+    if check_interval is not None:
+        update_user_usage(current_user, check_interval, "remove")
+
+
+def _query_location_filter(item_location: str | None) -> str | None:
+    return None if item_location in (None, "", "any") else item_location
+
+
+def _optional_text(value: str | None) -> str | None:
+    return value or None
+
+
+def _text_value(value: str | None) -> str:
+    return value or ""

--- a/app/searches/__init__.py
+++ b/app/searches/__init__.py
@@ -1,10 +1,22 @@
+from app.searches.definitions import SavedSearch, SearchFilters, SearchSchedule
 from app.searches.execution import EbaySearchExecutor, scrape_ebay, scrape_new_items
 from app.searches.item_processor import SearchItemProcessor, process_items
+from app.searches.mapping import saved_search_from_model, to_ebay_search_params
+from app.searches.onboarding import SearchOnboardingService
+from app.searches.validation import ensure_valid_saved_search, validate_saved_search
 
 __all__ = [
     "EbaySearchExecutor",
+    "SavedSearch",
+    "SearchFilters",
+    "SearchOnboardingService",
+    "SearchSchedule",
     "SearchItemProcessor",
+    "ensure_valid_saved_search",
     "process_items",
+    "saved_search_from_model",
     "scrape_ebay",
     "scrape_new_items",
+    "to_ebay_search_params",
+    "validate_saved_search",
 ]

--- a/app/searches/definitions.py
+++ b/app/searches/definitions.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class SearchFilters:
+    """Hard filters and legacy keyword gates for a saved search."""
+
+    min_price: Optional[Decimal] = None
+    max_price: Optional[Decimal] = None
+    item_location: Optional[str] = "GB"
+    condition: Optional[str] = None
+    buying_options: str = "FIXED_PRICE|AUCTION"
+    required_keywords: Optional[str] = None
+    excluded_keywords: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class SearchSchedule:
+    """Scheduling state for recurring search execution."""
+
+    check_interval: int = 5
+    first_run: bool = True
+    last_full_run: Optional[datetime] = None
+    next_full_run: Optional[datetime] = None
+    last_recent_run: Optional[datetime] = None
+
+
+@dataclass(frozen=True)
+class SavedSearch:
+    """Domain representation of a user's saved eBay search."""
+
+    id: str
+    user_id: int
+    keyword_id: int
+    keywords: str
+    marketplace: str
+    is_active: bool
+    filters: SearchFilters
+    schedule: SearchSchedule

--- a/app/searches/execution.py
+++ b/app/searches/execution.py
@@ -1,34 +1,38 @@
 from threading import local
+from typing import Any, Callable, Optional
 
 from circuitbreaker import circuit
 
 from ebay_client import EbayClient
+from app.searches.definitions import SavedSearch
+from app.searches.mapping import to_ebay_search_params
 from app.utils.text_helpers import filter_items_by_keywords
-
 
 _thread_local = local()
 
 
-def create_ebay_client():
+def create_ebay_client() -> EbayClient:
     if not hasattr(_thread_local, "ebay_client"):
         _thread_local.ebay_client = EbayClient()
     return _thread_local.ebay_client
 
 
 class EbaySearchExecutor:
-    def __init__(self, api_factory=create_ebay_client):
+    def __init__(
+        self, api_factory: Callable[[], EbayClient] = create_ebay_client
+    ) -> None:
         self.api_factory = api_factory
 
     def execute(
         self,
-        keywords,
-        filters=None,
-        marketplace="EBAY_GB",
-        required_keywords=None,
-        excluded_keywords=None,
-        sort_order="newlyListed",
-        max_pages=1,
-    ):
+        keywords: str,
+        filters: Optional[dict[str, Any]] = None,
+        marketplace: str = "EBAY_GB",
+        required_keywords: Optional[str] = None,
+        excluded_keywords: Optional[str] = None,
+        sort_order: str = "newlyListed",
+        max_pages: int = 1,
+    ) -> list[dict[str, Any]]:
         api = self.api_factory()
         items = api.search_items(
             keywords=keywords,
@@ -38,6 +42,23 @@ class EbaySearchExecutor:
             marketplace=marketplace,
         )
         return filter_items_by_keywords(items, required_keywords, excluded_keywords)
+
+    def execute_saved_search(
+        self,
+        saved_search: SavedSearch,
+        sort_order: str = "newlyListed",
+        max_pages: int = 1,
+    ) -> list[dict[str, Any]]:
+        params = to_ebay_search_params(saved_search)
+        return self.execute(
+            keywords=params["keywords"],
+            filters=params["filters"],
+            marketplace=params["marketplace"],
+            required_keywords=saved_search.filters.required_keywords,
+            excluded_keywords=saved_search.filters.excluded_keywords,
+            sort_order=sort_order,
+            max_pages=max_pages,
+        )
 
 
 @circuit(failure_threshold=3, recovery_timeout=60)

--- a/app/searches/mapping.py
+++ b/app/searches/mapping.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Optional
+
+from app.searches.definitions import SavedSearch, SearchFilters, SearchSchedule
+
+
+def saved_search_from_model(user_query: Any) -> SavedSearch:
+    """Map a UserQuery ORM object to a SavedSearch domain object."""
+
+    keywords = _keywords_for_query(user_query)
+    saved_search = SavedSearch(
+        id=str(user_query.query_id),
+        user_id=int(user_query.user_id),
+        keyword_id=int(user_query.keyword_id),
+        keywords=keywords,
+        marketplace=user_query.marketplace or "EBAY_GB",
+        is_active=bool(user_query.is_active),
+        filters=SearchFilters(
+            min_price=_optional_decimal(user_query.min_price),
+            max_price=_optional_decimal(user_query.max_price),
+            item_location=user_query.item_location,
+            condition=user_query.condition,
+            buying_options=user_query.buying_options or "FIXED_PRICE|AUCTION",
+            required_keywords=user_query.required_keywords,
+            excluded_keywords=user_query.excluded_keywords,
+        ),
+        schedule=SearchSchedule(
+            check_interval=int(user_query.check_interval or 5),
+            first_run=bool(user_query.first_run),
+            last_full_run=user_query.last_full_run,
+            next_full_run=user_query.next_full_run,
+            last_recent_run=user_query.last_recent_run,
+        ),
+    )
+    return saved_search
+
+
+def to_ebay_search_params(saved_search: SavedSearch) -> dict[str, Any]:
+    """Return public EbayClient search parameters for a saved search."""
+
+    return {
+        "keywords": saved_search.keywords,
+        "filters": {
+            "min_price": _decimal_to_float(saved_search.filters.min_price),
+            "max_price": _decimal_to_float(saved_search.filters.max_price),
+            "item_location": saved_search.filters.item_location,
+            "condition": saved_search.filters.condition,
+            "buying_options": saved_search.filters.buying_options,
+        },
+        "marketplace": saved_search.marketplace,
+    }
+
+
+def _keywords_for_query(user_query: Any) -> str:
+    keyword = getattr(user_query, "keyword", None)
+    if keyword is not None and getattr(keyword, "keyword_text", None):
+        return str(keyword.keyword_text)
+    if getattr(user_query, "keywords", None):
+        return str(user_query.keywords)
+    raise ValueError("Saved search requires keyword text")
+
+
+def _optional_decimal(value: Any) -> Optional[Decimal]:
+    if value is None:
+        return None
+    return Decimal(str(value))
+
+
+def _decimal_to_float(value: Optional[Decimal]) -> Optional[float]:
+    if value is None:
+        return None
+    return float(value)

--- a/app/searches/onboarding.py
+++ b/app/searches/onboarding.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from app.searches.definitions import SavedSearch
+from app.searches.execution import create_ebay_client
+from app.searches.mapping import to_ebay_search_params
+from app.searches.sampling import diverse_items
+from app.searches.validation import ensure_valid_saved_search
+from app.utils.text_helpers import filter_items_by_keywords
+
+DEFAULT_PREVIEW_LIMIT = 20
+MAX_CANDIDATES = 100
+
+
+class EbayPreviewClient(Protocol):
+    """Public eBay client methods used for onboarding previews."""
+
+    def search_item_summaries(
+        self,
+        keywords: str,
+        filters: dict[str, Any] | None = None,
+        limit: int = MAX_CANDIDATES,
+        offset: int = 0,
+        sort_order: str | None = None,
+        marketplace: str | None = None,
+    ) -> dict[str, Any]:
+        """Fetch raw item summaries from eBay."""
+        ...
+
+    def parse_item_summary_response(
+        self, response: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Parse eBay item summaries into app item dictionaries."""
+        ...
+
+
+class SearchOnboardingService:
+    """Build labelled-training previews for saved searches."""
+
+    def __init__(self, ebay_client_factory=create_ebay_client) -> None:
+        self.ebay_client_factory = ebay_client_factory
+
+    def create_preview(
+        self, saved_search: SavedSearch, limit: int = DEFAULT_PREVIEW_LIMIT
+    ) -> list[dict[str, Any]]:
+        """Return diverse candidate dicts ready for likely/not-likely labels."""
+
+        ensure_valid_saved_search(saved_search)
+        if limit <= 0:
+            return []
+
+        candidate_limit = _candidate_limit(limit)
+        candidates = self._fetch_candidates(saved_search, candidate_limit)
+        filtered = filter_items_by_keywords(
+            candidates,
+            saved_search.filters.required_keywords,
+            saved_search.filters.excluded_keywords,
+        )
+        selected = diverse_items(filtered, limit)
+        return [_preview_item(saved_search.id, item) for item in selected]
+
+    def _fetch_candidates(
+        self, saved_search: SavedSearch, candidate_limit: int
+    ) -> list[dict[str, Any]]:
+        client = self.ebay_client_factory()
+        params = to_ebay_search_params(saved_search)
+        raw_response = client.search_item_summaries(
+            keywords=params["keywords"],
+            filters=params["filters"],
+            limit=candidate_limit,
+            offset=0,
+            sort_order="newlyListed",
+            marketplace=params["marketplace"],
+        )
+        return client.parse_item_summary_response(raw_response)
+
+
+def _candidate_limit(limit: int) -> int:
+    if limit <= 0:
+        return 0
+    return min(max(limit * 5, limit), MAX_CANDIDATES)
+
+
+def _preview_item(search_id: str, item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "search_id": search_id,
+        "item_id": item.get("ebay_id") or item.get("item_id"),
+        "title": item.get("title"),
+        "price": item.get("price"),
+        "currency": item.get("currency"),
+        "condition": item.get("condition"),
+        "location": item.get("location"),
+        "buying_options": item.get("buying_options"),
+        "url": item.get("url"),
+        "image_url": item.get("image_url"),
+        "seller": item.get("seller"),
+        "likely_to_buy": None,
+        "not_likely_to_buy": None,
+    }

--- a/app/searches/sampling.py
+++ b/app/searches/sampling.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+from decimal import Decimal, InvalidOperation
+from difflib import SequenceMatcher
+from typing import Any, Optional
+
+NEAR_DUPLICATE_THRESHOLD = 0.86
+
+
+def diverse_items(items: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    """Select diverse items while avoiding near-duplicate titles."""
+
+    if limit <= 0:
+        return []
+
+    selected: list[dict[str, Any]] = []
+    remaining = list(items)
+    price_bands = _price_bands(items)
+
+    while remaining and len(selected) < limit:
+        best = _best_candidate(remaining, selected, price_bands)
+        if best is None:
+            break
+        selected.append(best)
+        remaining.remove(best)
+
+    return selected
+
+
+def _best_candidate(
+    candidates: list[dict[str, Any]],
+    selected: list[dict[str, Any]],
+    price_bands: dict[int, str],
+) -> Optional[dict[str, Any]]:
+    selected_titles = [_normalized_title(item) for item in selected]
+    selectable = [
+        item
+        for item in candidates
+        if not _is_near_duplicate(_normalized_title(item), selected_titles)
+    ]
+    if not selectable:
+        return None
+
+    condition_counts = Counter(_condition(item) for item in selected)
+    location_counts = Counter(_location(item) for item in selected)
+    price_band_counts = Counter(_price_band(item, price_bands) for item in selected)
+
+    return max(
+        selectable,
+        key=lambda item: (
+            _rarity_score(_condition(item), condition_counts),
+            _rarity_score(_location(item), location_counts),
+            _rarity_score(_price_band(item, price_bands), price_band_counts),
+            -candidates.index(item),
+        ),
+    )
+
+
+def _rarity_score(value: str, counts: Counter[str]) -> int:
+    if value == "unknown":
+        return 0
+    return -counts[value]
+
+
+def _normalized_title(item: dict[str, Any]) -> str:
+    title = str(item.get("title") or "").lower()
+    return re.sub(r"\W+", " ", title).strip()
+
+
+def _is_near_duplicate(title: str, selected_titles: list[str]) -> bool:
+    if not title:
+        return False
+    return any(
+        SequenceMatcher(None, title, selected_title).ratio() >= NEAR_DUPLICATE_THRESHOLD
+        for selected_title in selected_titles
+    )
+
+
+def _condition(item: dict[str, Any]) -> str:
+    return str(item.get("condition") or "unknown").lower()
+
+
+def _location(item: dict[str, Any]) -> str:
+    location = item.get("location")
+    if isinstance(location, dict):
+        return str(location.get("country") or "unknown").lower()
+    return str(location or item.get("item_location") or "unknown").lower()
+
+
+def _price_band(item: dict[str, Any], price_bands: dict[int, str]) -> str:
+    return price_bands.get(id(item), "unknown")
+
+
+def _price_bands(items: list[dict[str, Any]]) -> dict[int, str]:
+    prices = sorted(
+        price for price in (_price(item) for item in items) if price is not None
+    )
+    if not prices:
+        return {}
+
+    low_cutoff = prices[len(prices) // 3]
+    high_cutoff = prices[(len(prices) * 2) // 3]
+    bands = {}
+    for item in items:
+        price = _price(item)
+        if price is None:
+            bands[id(item)] = "unknown"
+        elif price <= low_cutoff:
+            bands[id(item)] = "low"
+        elif price <= high_cutoff:
+            bands[id(item)] = "mid"
+        else:
+            bands[id(item)] = "high"
+    return bands
+
+
+def _price(item: dict[str, Any]) -> Optional[Decimal]:
+    value = item.get("price")
+    if isinstance(value, dict):
+        value = value.get("value")
+    try:
+        return Decimal(str(value)) if value not in (None, "") else None
+    except (InvalidOperation, TypeError):
+        return None

--- a/app/searches/validation.py
+++ b/app/searches/validation.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from app.searches.definitions import SavedSearch, SearchFilters, SearchSchedule
+
+MIN_CHECK_INTERVAL_MINUTES = 5
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """A structured validation failure for search-domain objects."""
+
+    field: str
+    message: str
+
+
+class SearchValidationError(ValueError):
+    """Raised when a search-domain object fails validation."""
+
+    def __init__(self, issues: list[ValidationIssue]) -> None:
+        self.issues = issues
+        message = "; ".join(f"{issue.field}: {issue.message}" for issue in issues)
+        super().__init__(message)
+
+
+def validate_search_schedule(schedule: SearchSchedule) -> list[ValidationIssue]:
+    """Return validation issues for a search schedule."""
+
+    issues: list[ValidationIssue] = []
+    if schedule.check_interval < MIN_CHECK_INTERVAL_MINUTES:
+        issues.append(
+            ValidationIssue(
+                field="schedule.check_interval",
+                message="must be at least 5 minutes",
+            )
+        )
+    return issues
+
+
+def validate_search_filters(filters: SearchFilters) -> list[ValidationIssue]:
+    """Return validation issues for search filters."""
+
+    issues: list[ValidationIssue] = []
+    if (
+        filters.min_price is not None
+        and filters.max_price is not None
+        and Decimal(filters.min_price) > Decimal(filters.max_price)
+    ):
+        issues.append(
+            ValidationIssue(
+                field="filters.max_price",
+                message="must be greater than or equal to min_price",
+            )
+        )
+    return issues
+
+
+def validate_saved_search(saved_search: SavedSearch) -> list[ValidationIssue]:
+    """Return validation issues for a saved search."""
+
+    issues = []
+    if not saved_search.keywords.strip():
+        issues.append(ValidationIssue(field="keywords", message="must not be blank"))
+    if not saved_search.marketplace.strip():
+        issues.append(ValidationIssue(field="marketplace", message="must not be blank"))
+
+    issues.extend(validate_search_filters(saved_search.filters))
+    issues.extend(validate_search_schedule(saved_search.schedule))
+    return issues
+
+
+def ensure_valid_saved_search(saved_search: SavedSearch) -> None:
+    """Raise SearchValidationError when a saved search is invalid."""
+
+    issues = validate_saved_search(saved_search)
+    if issues:
+        raise SearchValidationError(issues)

--- a/app/tests/test_query_routes_backend.py
+++ b/app/tests/test_query_routes_backend.py
@@ -1,0 +1,86 @@
+from decimal import Decimal
+from types import SimpleNamespace
+
+from app.routes import queries
+
+
+def _saved_search_model(**overrides):
+    values = {
+        "query_id": "query-1",
+        "user_id": 12,
+        "keyword_id": 34,
+        "keyword": SimpleNamespace(keyword_text="Sony Camera"),
+        "marketplace": "EBAY_GB",
+        "is_active": True,
+        "min_price": Decimal("10.00"),
+        "max_price": Decimal("200.00"),
+        "item_location": "any",
+        "condition": "",
+        "buying_options": "FIXED_PRICE|AUCTION",
+        "required_keywords": "sony",
+        "excluded_keywords": "charger",
+        "check_interval": 15,
+        "first_run": True,
+        "last_full_run": None,
+        "next_full_run": None,
+        "last_recent_run": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_saved_search_from_model_preserves_legacy_keyword_filters():
+    saved_search = queries.saved_search_from_model(_saved_search_model())
+
+    assert saved_search.id == "query-1"
+    assert saved_search.keywords == "Sony Camera"
+    assert saved_search.filters.item_location is None
+    assert saved_search.filters.required_keywords == "sony"
+    assert saved_search.filters.excluded_keywords == "charger"
+    assert saved_search.schedule.check_interval == 15
+
+
+def test_to_ebay_search_params_omits_empty_filter_values():
+    saved_search = queries.saved_search_from_model(
+        _saved_search_model(max_price=None, condition=None, item_location="GB")
+    )
+
+    params = queries.to_ebay_search_params(saved_search)
+
+    assert params["keywords"] == "Sony Camera"
+    assert params["marketplace"] == "EBAY_GB"
+    assert params["required_keywords"] == "sony"
+    assert params["excluded_keywords"] == "charger"
+    assert params["filters"] == {
+        "min_price": Decimal("10.00"),
+        "item_location": "GB",
+        "buying_options": "FIXED_PRICE|AUCTION",
+    }
+
+
+def test_item_matches_saved_search_keeps_hard_filters_required():
+    saved_search = queries.saved_search_from_model(
+        _saved_search_model(item_location="GB")
+    )
+    matching_item = SimpleNamespace(
+        title="Sony mirrorless camera body",
+        location_country="GB",
+        marketplace="EBAY_GB",
+    )
+    excluded_item = SimpleNamespace(
+        title="Sony camera charger",
+        location_country="GB",
+        marketplace="EBAY_GB",
+    )
+    wrong_marketplace_item = SimpleNamespace(
+        title="Sony mirrorless camera body",
+        location_country="GB",
+        marketplace="EBAY_US",
+    )
+
+    assert queries._item_matches_saved_search(matching_item, saved_search) is True
+    assert queries._item_matches_saved_search(excluded_item, saved_search) is False
+    assert (
+        queries._item_matches_saved_search(wrong_marketplace_item, saved_search)
+        is False
+    )

--- a/app/tests/test_query_routes_backend.py
+++ b/app/tests/test_query_routes_backend.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from types import SimpleNamespace
 
 from app.routes import queries
+from app.searches import saved_search_from_model, to_ebay_search_params
 
 
 def _saved_search_model(**overrides):
@@ -30,38 +31,36 @@ def _saved_search_model(**overrides):
 
 
 def test_saved_search_from_model_preserves_legacy_keyword_filters():
-    saved_search = queries.saved_search_from_model(_saved_search_model())
+    saved_search = saved_search_from_model(_saved_search_model())
 
     assert saved_search.id == "query-1"
     assert saved_search.keywords == "Sony Camera"
-    assert saved_search.filters.item_location is None
+    assert saved_search.filters.item_location == "any"
     assert saved_search.filters.required_keywords == "sony"
     assert saved_search.filters.excluded_keywords == "charger"
     assert saved_search.schedule.check_interval == 15
 
 
-def test_to_ebay_search_params_omits_empty_filter_values():
-    saved_search = queries.saved_search_from_model(
+def test_to_ebay_search_params_uses_shared_sdk_filter_shape():
+    saved_search = saved_search_from_model(
         _saved_search_model(max_price=None, condition=None, item_location="GB")
     )
 
-    params = queries.to_ebay_search_params(saved_search)
+    params = to_ebay_search_params(saved_search)
 
     assert params["keywords"] == "Sony Camera"
     assert params["marketplace"] == "EBAY_GB"
-    assert params["required_keywords"] == "sony"
-    assert params["excluded_keywords"] == "charger"
     assert params["filters"] == {
-        "min_price": Decimal("10.00"),
+        "min_price": 10.0,
+        "max_price": None,
         "item_location": "GB",
+        "condition": None,
         "buying_options": "FIXED_PRICE|AUCTION",
     }
 
 
 def test_item_matches_saved_search_keeps_hard_filters_required():
-    saved_search = queries.saved_search_from_model(
-        _saved_search_model(item_location="GB")
-    )
+    saved_search = saved_search_from_model(_saved_search_model(item_location="GB"))
     matching_item = SimpleNamespace(
         title="Sony mirrorless camera body",
         location_country="GB",
@@ -84,3 +83,14 @@ def test_item_matches_saved_search_keeps_hard_filters_required():
         queries._item_matches_saved_search(wrong_marketplace_item, saved_search)
         is False
     )
+
+
+def test_item_matches_saved_search_treats_any_location_as_unconstrained():
+    saved_search = saved_search_from_model(_saved_search_model(item_location="any"))
+    matching_item = SimpleNamespace(
+        title="Sony mirrorless camera body",
+        location_country="US",
+        marketplace="EBAY_GB",
+    )
+
+    assert queries._item_matches_saved_search(matching_item, saved_search) is True

--- a/app/tests/test_search_domain.py
+++ b/app/tests/test_search_domain.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from app.searches.definitions import SavedSearch, SearchFilters, SearchSchedule
+from app.searches.mapping import saved_search_from_model, to_ebay_search_params
+from app.searches.validation import SearchValidationError, ensure_valid_saved_search
+
+
+@dataclass
+class KeywordStub:
+    keyword_text: str
+
+
+@dataclass
+class UserQueryStub:
+    query_id: str
+    user_id: int
+    keyword_id: int
+    keyword: KeywordStub
+    marketplace: str
+    is_active: bool
+    min_price: Decimal | None
+    max_price: Decimal | None
+    item_location: str
+    condition: str
+    buying_options: str
+    required_keywords: str
+    excluded_keywords: str
+    check_interval: int
+    first_run: bool
+    last_full_run: datetime | None
+    next_full_run: datetime | None
+    last_recent_run: datetime | None
+
+
+def test_saved_search_from_model_maps_query_fields() -> None:
+    last_full_run = datetime(2026, 4, 28, tzinfo=timezone.utc)
+    query = UserQueryStub(
+        query_id="search-1",
+        user_id=7,
+        keyword_id=11,
+        keyword=KeywordStub(keyword_text="sony camera"),
+        marketplace="EBAY_GB",
+        is_active=True,
+        min_price=Decimal("10.50"),
+        max_price=Decimal("250.00"),
+        item_location="GB",
+        condition="USED",
+        buying_options="AUCTION",
+        required_keywords="sony",
+        excluded_keywords="broken",
+        check_interval=15,
+        first_run=False,
+        last_full_run=last_full_run,
+        next_full_run=None,
+        last_recent_run=None,
+    )
+
+    saved_search = saved_search_from_model(query)
+
+    assert saved_search == SavedSearch(
+        id="search-1",
+        user_id=7,
+        keyword_id=11,
+        keywords="sony camera",
+        marketplace="EBAY_GB",
+        is_active=True,
+        filters=SearchFilters(
+            min_price=Decimal("10.50"),
+            max_price=Decimal("250.00"),
+            item_location="GB",
+            condition="USED",
+            buying_options="AUCTION",
+            required_keywords="sony",
+            excluded_keywords="broken",
+        ),
+        schedule=SearchSchedule(
+            check_interval=15,
+            first_run=False,
+            last_full_run=last_full_run,
+            next_full_run=None,
+            last_recent_run=None,
+        ),
+    )
+
+
+def test_to_ebay_search_params_uses_sdk_filter_shape() -> None:
+    saved_search = SavedSearch(
+        id="search-1",
+        user_id=7,
+        keyword_id=11,
+        keywords="sony camera",
+        marketplace="EBAY_GB",
+        is_active=True,
+        filters=SearchFilters(
+            min_price=Decimal("10.50"),
+            max_price=Decimal("250.00"),
+            item_location="GB",
+            condition="USED",
+            buying_options="AUCTION",
+            required_keywords="sony",
+            excluded_keywords="broken",
+        ),
+        schedule=SearchSchedule(check_interval=5),
+    )
+
+    params = to_ebay_search_params(saved_search)
+
+    assert params == {
+        "keywords": "sony camera",
+        "filters": {
+            "min_price": 10.5,
+            "max_price": 250.0,
+            "item_location": "GB",
+            "condition": "USED",
+            "buying_options": "AUCTION",
+        },
+        "marketplace": "EBAY_GB",
+    }
+
+
+def test_validation_rejects_intervals_below_five_minutes() -> None:
+    saved_search = SavedSearch(
+        id="search-1",
+        user_id=7,
+        keyword_id=11,
+        keywords="sony camera",
+        marketplace="EBAY_GB",
+        is_active=True,
+        filters=SearchFilters(),
+        schedule=SearchSchedule(check_interval=4),
+    )
+
+    with pytest.raises(SearchValidationError) as exc_info:
+        ensure_valid_saved_search(saved_search)
+
+    assert "schedule.check_interval: must be at least 5 minutes" in str(exc_info.value)

--- a/app/tests/test_search_onboarding.py
+++ b/app/tests/test_search_onboarding.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+
+from app.searches.definitions import SavedSearch, SearchFilters, SearchSchedule
+from app.searches.onboarding import SearchOnboardingService
+
+
+@dataclass
+class FakeEbayClient:
+    items: list[dict[str, Any]]
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def search_item_summaries(
+        self,
+        keywords: str,
+        filters: dict[str, Any] | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        sort_order: str | None = None,
+        marketplace: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "keywords": keywords,
+                "filters": filters,
+                "limit": limit,
+                "offset": offset,
+                "sort_order": sort_order,
+                "marketplace": marketplace,
+            }
+        )
+        return {"items": self.items[:limit]}
+
+    def parse_item_summary_response(
+        self, response: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        return list(response["items"])
+
+
+def test_create_preview_filters_legacy_keywords_and_labels_items() -> None:
+    fake_client = FakeEbayClient(
+        items=[
+            _item("1", "Sony Alpha camera body", 100, "USED", "GB"),
+            _item("2", "Sony Alpha camera body boxed", 110, "USED", "GB"),
+            _item("3", "Sony Alpha camera lens", 300, "NEW", "US"),
+            _item("4", "Sony Alpha camera broken", 50, "USED", "GB"),
+            _item("5", "Canon camera body", 150, "USED", "GB"),
+            _item("6", "Sony Alpha camera kit", 500, "NEW", "DE"),
+        ]
+    )
+    service = SearchOnboardingService(ebay_client_factory=lambda: fake_client)
+
+    preview = service.create_preview(_saved_search(), limit=3)
+
+    assert fake_client.calls[0]["limit"] == 15
+    assert fake_client.calls[0]["marketplace"] == "EBAY_GB"
+    assert [item["item_id"] for item in preview] == ["1", "3", "6"]
+    assert all(item["likely_to_buy"] is None for item in preview)
+    assert all(item["not_likely_to_buy"] is None for item in preview)
+
+
+def test_create_preview_fetches_at_most_one_hundred_candidates() -> None:
+    fake_client = FakeEbayClient(
+        items=[
+            _item(str(index), f"Sony camera {index}", index, "USED", "GB")
+            for index in range(150)
+        ]
+    )
+    service = SearchOnboardingService(ebay_client_factory=lambda: fake_client)
+
+    service.create_preview(_saved_search(), limit=25)
+
+    assert fake_client.calls[0]["limit"] == 100
+
+
+def _saved_search() -> SavedSearch:
+    return SavedSearch(
+        id="search-1",
+        user_id=7,
+        keyword_id=11,
+        keywords="sony camera",
+        marketplace="EBAY_GB",
+        is_active=True,
+        filters=SearchFilters(
+            min_price=Decimal("50"),
+            max_price=Decimal("500"),
+            item_location="GB",
+            condition="USED",
+            buying_options="FIXED_PRICE|AUCTION",
+            required_keywords="sony, camera",
+            excluded_keywords="broken, canon",
+        ),
+        schedule=SearchSchedule(check_interval=5),
+    )
+
+
+def _item(
+    item_id: str,
+    title: str,
+    price: int,
+    condition: str,
+    country: str,
+) -> dict[str, Any]:
+    return {
+        "ebay_id": item_id,
+        "title": title,
+        "price": price,
+        "currency": "GBP",
+        "condition": condition,
+        "location": {"country": country},
+        "buying_options": "FIXED_PRICE",
+        "url": f"https://example.test/{item_id}",
+        "image_url": f"https://example.test/{item_id}.jpg",
+        "seller": "seller",
+    }


### PR DESCRIPTION
Closes #23

Depends on #68 for the shared `app.searches` search-domain interfaces. This branch is currently stacked with the PR #68 commit so the route imports are runnable before #68 lands.

## What changed
- Rebases PR #66 onto latest `origin/develop` (`5048263`).
- Replaces PR #66 route-local `SearchFilters`, `SearchSchedule`, `SavedSearch`, `saved_search_from_model`, and `to_ebay_search_params` duplicates with shared `app.searches` imports from PR #68.
- Keeps `app/routes/queries.py` route handlers thin through route-local helpers for form mapping, duplicate checks, usage updates, historical item linking, query details context, and feedback redirects.
- Preserves route-specific behavior for `item_location='any'` by handling it as no location constraint in route filtering helpers.
- Updates route backend tests to use the shared `app.searches` mappers and verify legacy hard filters still apply.

## Preserved behavior
- Existing route names, URLs, template names, flash messages, and create/edit/delete/toggle/feedback/detail flows.
- Legacy required/excluded keyword filters remain hard filters.
- Existing relevance feedback submission still uses `RelevanceFeedbackService`.
- Historical item linking continues to skip items the user marked irrelevant.

## New behavior
- Query routes now consume the shared search-domain interfaces instead of defining route-local duplicates.
- Create search uses the same explicit login guard as edit/delete.
- Query usage interval replacement restores the old interval if adding the new interval fails.

## Validation
- `/Users/oscaralberigo/Desktop/coco-search/venv/bin/pytest app/tests/test_query_routes_backend.py app/tests/test_search_domain.py` passed: 7 tests.
- `python3 -m compileall app ebay_client config.py` passed.
- `/Users/oscaralberigo/Desktop/coco-search/venv/bin/black .` was run as required; formatter-only changes outside this task, including `ebay_client/**`, were restored. Targeted black on route-owned files then passed unchanged.
- `/Users/oscaralberigo/Desktop/coco-search/venv/bin/pytest` was run and still fails during collection on existing suite issues: stale imports for `Query`, `archive_items`, `load_historical_items`; missing local `stripe`; and missing `ENCRYPTION_KEY`.
- `/Users/oscaralberigo/Desktop/coco-search/venv/bin/mypy .` was run and still fails on existing project-wide missing stubs/imports plus stale tests.

## Migrations
- None added by this route PR.

## Risks / open questions
- This PR is stacked on #68. Once #68 merges into `develop`, PR #66 should be rebased again so the diff collapses to route-owned files only.
- Full-suite pytest/mypy need separate cleanup for stale tests and local dependency/config setup.