### PR TITLE
[codex] Add repository persistence wrappers

### DIFF
--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -1,4 +1,33 @@
-from app.repositories.items import ItemRepository
-from app.repositories.queries import UserQueryRepository
+from app.repositories._models import RepositoryModelUnavailable
+from app.repositories.events import DomainEventRepository
+from app.repositories.features import ItemFeatureSnapshotRepository
+from app.repositories.interactions import FeedbackRepository, InteractionRepository
+from app.repositories.items import (
+    GlobalItemRepository,
+    ItemFeedbackRepository,
+    ItemRepository,
+    KeywordItemLinkRepository,
+    SearchItemLinkRepository,
+)
+from app.repositories.notifications import NotificationRecordRepository
+from app.repositories.observations import ItemObservationRepository
+from app.repositories.queries import KeywordRepository, UserQueryRepository
+from app.repositories.runs import SearchRunRepository
 
-__all__ = ["ItemRepository", "UserQueryRepository"]
+__all__ = [
+    "DomainEventRepository",
+    "FeedbackRepository",
+    "GlobalItemRepository",
+    "InteractionRepository",
+    "ItemFeedbackRepository",
+    "ItemFeatureSnapshotRepository",
+    "ItemObservationRepository",
+    "ItemRepository",
+    "KeywordRepository",
+    "KeywordItemLinkRepository",
+    "NotificationRecordRepository",
+    "RepositoryModelUnavailable",
+    "SearchRunRepository",
+    "SearchItemLinkRepository",
+    "UserQueryRepository",
+]

--- a/app/repositories/_models.py
+++ b/app/repositories/_models.py
@@ -1,0 +1,66 @@
+"""Shared helpers for repository model access."""
+
+from typing import Any, Optional, Type
+
+from sqlalchemy import inspect
+
+from app.extensions import db
+from app import models
+
+
+class RepositoryModelUnavailable(RuntimeError):
+    """Raised when a repository depends on a model not present in this branch."""
+
+
+def default_session() -> Any:
+    """Return the default SQLAlchemy session used by repositories."""
+    return db.session
+
+
+def optional_model(model_name: str) -> Optional[Type[Any]]:
+    """Return a model class if it exists on app.models."""
+    return getattr(models, model_name, None)
+
+
+def require_model(model: Optional[Type[Any]], model_name: str) -> Type[Any]:
+    """Return a model class or raise a clear schema dependency error."""
+    if model is None:
+        message = (
+            f"{model_name} model is not available. This repository method depends "
+            "on the schema-worker model for that table."
+        )
+        raise RepositoryModelUnavailable(message)
+    return model
+
+
+def model_columns(model: Type[Any]) -> set[str]:
+    """Return mapped column names for a SQLAlchemy model."""
+    return {column.key for column in inspect(model).mapper.column_attrs}
+
+
+def compact_values(values: dict[str, Any]) -> dict[str, Any]:
+    """Drop unset values before constructing or updating models."""
+    return {key: value for key, value in values.items() if value is not None}
+
+
+def create_model(model: Type[Any], values: dict[str, Any]) -> Any:
+    """Create a model instance from values that match mapped columns."""
+    columns = model_columns(model)
+    return model(
+        **{
+            key: value
+            for key, value in compact_values(values).items()
+            if key in columns
+        }
+    )
+
+
+def update_model(instance: Any, values: dict[str, Any]) -> bool:
+    """Update mapped attributes on an instance and report whether anything changed."""
+    changed = False
+    columns = model_columns(type(instance))
+    for key, value in compact_values(values).items():
+        if key in columns and getattr(instance, key) != value:
+            setattr(instance, key, value)
+            changed = True
+    return changed

--- a/app/repositories/_optional.py
+++ b/app/repositories/_optional.py
@@ -1,0 +1,53 @@
+"""Repository base class for schema-worker tables that may not exist yet."""
+
+from datetime import datetime, timezone
+from typing import Any, Optional, Type
+
+from app.repositories._models import (
+    compact_values,
+    create_model,
+    default_session,
+    optional_model,
+    require_model,
+    update_model,
+)
+
+
+class OptionalModelRepository:
+    """Small repository wrapper around a model that may arrive in another branch."""
+
+    model_name = ""
+
+    def __init__(
+        self, session: Optional[Any] = None, model: Optional[Type[Any]] = None
+    ):
+        self.session = session or default_session()
+        self._model = model or optional_model(self.model_name)
+
+    @property
+    def model(self) -> Type[Any]:
+        """Return the configured model or raise a clear dependency error."""
+        return require_model(self._model, self.model_name)
+
+    def get(self, record_id: Any) -> Any:
+        """Return one record by primary key."""
+        return self.session.get(self.model, record_id)
+
+    def add(self, values: dict[str, Any]) -> Any:
+        """Create and add one model instance."""
+        record = create_model(self.model, values)
+        self.session.add(record)
+        self.session.flush()
+        return record
+
+    def update(self, record: Any, values: dict[str, Any]) -> bool:
+        """Update one record with mapped values."""
+        return update_model(record, values)
+
+    def now(self) -> datetime:
+        """Return a timezone-aware timestamp for repository defaults."""
+        return datetime.now(timezone.utc)
+
+    def values(self, **values: Any) -> dict[str, Any]:
+        """Return non-null values for model construction."""
+        return compact_values(values)

--- a/app/repositories/events.py
+++ b/app/repositories/events.py
@@ -1,0 +1,49 @@
+from typing import Any, Optional
+
+from app.repositories._optional import OptionalModelRepository
+
+
+class DomainEventRepository(OptionalModelRepository):
+    """Persistence operations for domain events.
+
+    This repository expects a DomainEvent model from the schema-worker branch
+    before its write methods can persist records.
+    """
+
+    model_name = "DomainEvent"
+
+    def create(
+        self,
+        event_type: str,
+        aggregate_type: str,
+        aggregate_id: Any,
+        payload: Optional[dict[str, Any]] = None,
+        status: str = "pending",
+        **extra: Any,
+    ) -> Any:
+        """Create one domain event record."""
+        values = self.values(
+            event_type=event_type,
+            aggregate_type=aggregate_type,
+            aggregate_id=aggregate_id,
+            status=status,
+            payload=payload or {},
+            occurred_at=extra.pop("occurred_at", self.now()),
+            **extra,
+        )
+        return self.add(values)
+
+    def mark_processed(self, event: Any, processed_at: Optional[Any] = None) -> Any:
+        """Mark a domain event as processed."""
+        self.update(event, self.values(processed_at=processed_at or self.now()))
+        self.session.flush()
+        return event
+
+    def list_unprocessed(self, limit: int = 100) -> list[Any]:
+        """Return unprocessed domain events in occurrence order."""
+        return (
+            self.model.query.filter_by(status="pending", processed_at=None)
+            .order_by(self.model.occurred_at.asc())
+            .limit(limit)
+            .all()
+        )

--- a/app/repositories/features.py
+++ b/app/repositories/features.py
@@ -1,0 +1,65 @@
+from typing import Any, Optional
+
+from app.repositories._optional import OptionalModelRepository
+
+
+class ItemFeatureSnapshotRepository(OptionalModelRepository):
+    """Persistence operations for item feature snapshots.
+
+    This repository expects an ItemFeatureSnapshot model from the schema-worker
+    branch before its write methods can persist records.
+    """
+
+    model_name = "ItemFeatureSnapshot"
+
+    def create(
+        self,
+        item_id: int,
+        query_id: Optional[Any] = None,
+        features: Optional[dict[str, Any]] = None,
+        search_run_id: Optional[int] = None,
+        feature_version: str = "v1",
+        model_version: Optional[str] = None,
+        search_id: Optional[Any] = None,
+        **extra: Any,
+    ) -> Any:
+        """Create one item feature snapshot."""
+        normalized_query_id = self._query_id(query_id=query_id, search_id=search_id)
+        values = self.values(
+            item_id=item_id,
+            query_id=normalized_query_id,
+            search_run_id=search_run_id,
+            feature_version=feature_version,
+            model_version=model_version,
+            features=features or {},
+            created_at=extra.pop("created_at", self.now()),
+            **extra,
+        )
+        return self.add(values)
+
+    def latest_for_item(self, item_id: int) -> Any:
+        """Return the latest feature snapshot for an item."""
+        return (
+            self.model.query.filter_by(item_id=item_id)
+            .order_by(self.model.created_at.desc())
+            .first()
+        )
+
+    def latest_for_search_item(self, search_id: Any, item_id: int) -> Any:
+        """Return the latest feature snapshot for a saved-search item pair."""
+        return self.latest_for_query_item(query_id=search_id, item_id=item_id)
+
+    def _query_id(self, query_id: Optional[Any], search_id: Optional[Any]) -> Any:
+        if query_id is not None:
+            return query_id
+        if search_id is not None:
+            return search_id
+        raise ValueError("query_id is required")
+
+    def latest_for_query_item(self, query_id: Any, item_id: int) -> Any:
+        """Return the latest feature snapshot for a saved-search item pair."""
+        return (
+            self.model.query.filter_by(query_id=query_id, item_id=item_id)
+            .order_by(self.model.created_at.desc())
+            .first()
+        )

--- a/app/repositories/interactions.py
+++ b/app/repositories/interactions.py
@@ -1,0 +1,144 @@
+from typing import Any, Optional, Type
+
+from app.extensions import db
+from app.models import ItemRelevanceFeedback, UserQuery
+from app.repositories._optional import OptionalModelRepository
+
+
+class FeedbackRepository:
+    """Persistence operations for relevance feedback using the legacy table."""
+
+    def __init__(self, session: Optional[Any] = None):
+        self.session = session or db.session
+
+    def get(
+        self, user_id: int, item_id: int, keyword_id: int
+    ) -> Optional[ItemRelevanceFeedback]:
+        """Return one relevance feedback record."""
+        return ItemRelevanceFeedback.query.filter_by(
+            user_id=user_id,
+            item_id=item_id,
+            keyword_id=keyword_id,
+        ).one_or_none()
+
+    def record(
+        self,
+        user_id: int,
+        item_id: int,
+        keyword_id: int,
+        is_relevant: Optional[bool],
+        **scores: Any,
+    ) -> ItemRelevanceFeedback:
+        """Create or update legacy relevance feedback."""
+        feedback = self.get(user_id, item_id, keyword_id)
+        if feedback is None:
+            feedback = ItemRelevanceFeedback(
+                user_id=user_id,
+                item_id=item_id,
+                keyword_id=keyword_id,
+            )
+            self.session.add(feedback)
+
+        feedback.is_relevant = is_relevant
+        self._update_scores(feedback, scores)
+        self.session.flush()
+        return feedback
+
+    def _update_scores(
+        self, feedback: ItemRelevanceFeedback, scores: dict[str, Any]
+    ) -> None:
+        for key in ("required_keywords", "excluded_keywords"):
+            if key in scores:
+                setattr(feedback, key, scores[key])
+
+        for key in ("simple_hybrid_levenshtein_confidence", "cosine_similarity"):
+            if key in scores:
+                setattr(feedback, key, scores[key])
+
+
+class InteractionRepository(OptionalModelRepository):
+    """Persistence operations for user item interactions.
+
+    The future schema is expected to expose a UserItemInteraction model. Until
+    then, relevance-style interactions are stored in ItemRelevanceFeedback.
+    """
+
+    model_name = "UserItemInteraction"
+
+    def __init__(
+        self,
+        session: Optional[Any] = None,
+        model: Optional[Type[Any]] = None,
+        feedback_repository: Optional[FeedbackRepository] = None,
+    ):
+        super().__init__(session=session, model=model)
+        self.feedback = feedback_repository or FeedbackRepository(self.session)
+
+    def record_interaction(
+        self,
+        user_id: int,
+        item_id: int,
+        interaction_type: str,
+        query_id: Optional[Any] = None,
+        label: Optional[Any] = None,
+        source: Optional[str] = None,
+        metadata_json: Optional[dict[str, Any]] = None,
+        search_id: Optional[Any] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        """Record a user interaction, falling back to legacy feedback when possible."""
+        normalized_query_id = self._query_id(query_id=query_id, search_id=search_id)
+        normalized_metadata = (
+            metadata_json if metadata_json is not None else metadata or {}
+        )
+        if self._model is not None:
+            return self.add(
+                self.values(
+                    user_id=user_id,
+                    query_id=normalized_query_id,
+                    item_id=item_id,
+                    interaction_type=interaction_type,
+                    label=label,
+                    source=source,
+                    metadata_json=normalized_metadata,
+                )
+            )
+
+        query = self._get_query(normalized_query_id)
+        relevance = self._relevance_label(interaction_type, label)
+        return self.feedback.record(
+            user_id=user_id,
+            item_id=item_id,
+            keyword_id=query.keyword_id,
+            is_relevant=relevance,
+        )
+
+    def _get_query(self, query_id: Any) -> UserQuery:
+        query = self.session.get(UserQuery, query_id)
+        if query is None:
+            raise ValueError(f"Saved search {query_id} was not found")
+        return query
+
+    def _query_id(self, query_id: Optional[Any], search_id: Optional[Any]) -> Any:
+        if query_id is not None:
+            return query_id
+        if search_id is not None:
+            return search_id
+        raise ValueError("query_id is required")
+
+    def _relevance_label(
+        self, interaction_type: str, label: Optional[Any]
+    ) -> Optional[bool]:
+        if isinstance(label, bool):
+            return label
+        if isinstance(label, str):
+            return self._string_label(label)
+        return self._string_label(interaction_type)
+
+    def _string_label(self, value: str) -> Optional[bool]:
+        normalized = value.lower().strip()
+        if normalized in {"relevant", "positive", "like", "liked"}:
+            return True
+        if normalized in {"irrelevant", "negative", "dislike", "dismissed", "hidden"}:
+            return False
+        return None

--- a/app/repositories/items.py
+++ b/app/repositories/items.py
@@ -1,35 +1,76 @@
-from sqlalchemy import inspect
+from datetime import datetime
+from typing import Any, Optional
 
 from app.extensions import db
 from app.models import Item, ItemRelevanceFeedback, KeywordItems, UserQueryItems
+from app.repositories._models import model_columns, update_model
 
 
-class ItemRepository:
-    def __init__(self, session=None):
+class GlobalItemRepository:
+    """Persistence operations for globally de-duplicated eBay items."""
+
+    def __init__(self, session: Optional[Any] = None):
         self.session = session or db.session
-        self.item_columns = {c.key for c in inspect(Item).mapper.column_attrs}
+        self.item_columns = model_columns(Item)
 
-    def get_by_ebay_id(self, ebay_id):
+    def get(self, item_id: int) -> Optional[Item]:
+        """Return one item by internal id."""
+        return self.session.get(Item, item_id)
+
+    def get_by_ebay_id(self, ebay_id: str) -> Optional[Item]:
+        """Return one item by eBay id."""
         return Item.query.filter_by(ebay_id=ebay_id).first()
 
-    def get_feedback(self, user_id, item_id, keyword_id):
-        return ItemRelevanceFeedback.query.filter_by(
-            user_id=user_id,
-            item_id=item_id,
-            keyword_id=keyword_id,
-        ).one_or_none()
-
-    def create_item(self, item_data):
-        valid_data = {k: v for k, v in item_data.items() if k in self.item_columns}
+    def create(self, item_data: dict[str, Any]) -> Item:
+        """Create an item from eBay payload data."""
+        valid_data = {
+            key: value for key, value in item_data.items() if key in self.item_columns
+        }
         item = Item(**valid_data)
-        item.location_country = item_data.get("location", {}).get("country")
-        item.postal_code = item_data.get("location", {}).get("postal_code")
+        location = item_data.get("location") or {}
+        item.location_country = location.get("country")
+        item.postal_code = location.get("postal_code")
         self.session.add(item)
         self.session.flush()
         return item
 
-    def link_keyword(self, keyword_id, item_id, found_at=None):
-        if KeywordItems.query.filter_by(keyword_id=keyword_id, item_id=item_id).first():
+    def update(
+        self, item: Item, item_data: dict[str, Any], updated_at: datetime
+    ) -> bool:
+        """Update mutable item fields and stamp the update time when changed."""
+        changed = update_model(item, self._updatable_values(item_data))
+        if changed:
+            item.last_updated = updated_at
+        return changed
+
+    def _updatable_values(self, item_data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in item_data.items()
+            if key in self.item_columns - {"item_id", "created_at"}
+        }
+
+
+class KeywordItemLinkRepository:
+    """Persistence operations for keyword-to-item discovery links."""
+
+    def __init__(self, session: Optional[Any] = None):
+        self.session = session or db.session
+
+    def get(self, keyword_id: int, item_id: int) -> Optional[KeywordItems]:
+        """Return one keyword-item link."""
+        return KeywordItems.query.filter_by(
+            keyword_id=keyword_id, item_id=item_id
+        ).first()
+
+    def create_if_missing(
+        self,
+        keyword_id: int,
+        item_id: int,
+        found_at: Optional[datetime] = None,
+    ) -> Optional[KeywordItems]:
+        """Create a keyword-item link unless it already exists."""
+        if self.get(keyword_id, item_id):
             return None
 
         link = KeywordItems(keyword_id=keyword_id, item_id=item_id)
@@ -38,8 +79,35 @@ class ItemRepository:
         self.session.add(link)
         return link
 
-    def link_query(self, query_id, item_id, created_at=None):
-        if UserQueryItems.query.filter_by(query_id=query_id, item_id=item_id).first():
+    def list_for_keyword(self, keyword_id: int) -> list[KeywordItems]:
+        """Return links for one keyword ordered by discovery time."""
+        return (
+            KeywordItems.query.filter_by(keyword_id=keyword_id)
+            .order_by(KeywordItems.found_at.desc())
+            .all()
+        )
+
+
+class SearchItemLinkRepository:
+    """Persistence operations for saved-search-to-item links."""
+
+    def __init__(self, session: Optional[Any] = None):
+        self.session = session or db.session
+
+    def get(self, query_id: Any, item_id: int) -> Optional[UserQueryItems]:
+        """Return one saved-search item link."""
+        return UserQueryItems.query.filter_by(
+            query_id=query_id, item_id=item_id
+        ).first()
+
+    def create_if_missing(
+        self,
+        query_id: Any,
+        item_id: int,
+        created_at: Optional[datetime] = None,
+    ) -> Optional[UserQueryItems]:
+        """Create a saved-search item link unless it already exists."""
+        if self.get(query_id, item_id):
             return None
 
         link = UserQueryItems(
@@ -52,17 +120,81 @@ class ItemRepository:
         self.session.add(link)
         return link
 
-    def get_query_item(self, query_id, item_id):
-        return UserQueryItems.query.filter_by(query_id=query_id, item_id=item_id).first()
+    def list_for_search(self, query_id: Any) -> list[UserQueryItems]:
+        """Return item links for a saved search ordered newest first."""
+        return (
+            UserQueryItems.query.filter_by(query_id=query_id)
+            .order_by(UserQueryItems.created_at.desc())
+            .all()
+        )
 
-    def update_item(self, item, item_data, updated_at):
-        changed = False
-        for key in self.item_columns - {"item_id", "created_at"}:
-            if key in item_data and getattr(item, key) != item_data[key]:
-                setattr(item, key, item_data[key])
-                changed = True
 
-        if changed:
-            item.last_updated = updated_at
+class ItemFeedbackRepository:
+    """Persistence operations for legacy item relevance feedback."""
 
-        return changed
+    def get(
+        self, user_id: int, item_id: int, keyword_id: int
+    ) -> Optional[ItemRelevanceFeedback]:
+        """Return one feedback record."""
+        return ItemRelevanceFeedback.query.filter_by(
+            user_id=user_id,
+            item_id=item_id,
+            keyword_id=keyword_id,
+        ).one_or_none()
+
+
+class ItemRepository:
+    """Backward-compatible item repository facade used by search processing."""
+
+    def __init__(self, session: Optional[Any] = None):
+        self.session = session or db.session
+        self.items = GlobalItemRepository(self.session)
+        self.item_columns = self.items.item_columns
+        self.keyword_links = KeywordItemLinkRepository(self.session)
+        self.search_links = SearchItemLinkRepository(self.session)
+        self.feedback = ItemFeedbackRepository()
+
+    def get_by_ebay_id(self, ebay_id: str) -> Optional[Item]:
+        """Return one item by eBay id."""
+        return self.items.get_by_ebay_id(ebay_id)
+
+    def get_feedback(
+        self,
+        user_id: int,
+        item_id: int,
+        keyword_id: int,
+    ) -> Optional[ItemRelevanceFeedback]:
+        """Return one legacy relevance feedback record."""
+        return self.feedback.get(user_id, item_id, keyword_id)
+
+    def create_item(self, item_data: dict[str, Any]) -> Item:
+        """Create a global item from eBay payload data."""
+        return self.items.create(item_data)
+
+    def link_keyword(
+        self,
+        keyword_id: int,
+        item_id: int,
+        found_at: Optional[datetime] = None,
+    ) -> Optional[KeywordItems]:
+        """Create a keyword-item link unless it already exists."""
+        return self.keyword_links.create_if_missing(keyword_id, item_id, found_at)
+
+    def link_query(
+        self,
+        query_id: Any,
+        item_id: int,
+        created_at: Optional[datetime] = None,
+    ) -> Optional[UserQueryItems]:
+        """Create a saved-search item link unless it already exists."""
+        return self.search_links.create_if_missing(query_id, item_id, created_at)
+
+    def get_query_item(self, query_id: Any, item_id: int) -> Optional[UserQueryItems]:
+        """Return one saved-search item link."""
+        return self.search_links.get(query_id, item_id)
+
+    def update_item(
+        self, item: Item, item_data: dict[str, Any], updated_at: datetime
+    ) -> bool:
+        """Update a global item and return whether it changed."""
+        return self.items.update(item, item_data, updated_at)

--- a/app/repositories/notifications.py
+++ b/app/repositories/notifications.py
@@ -1,0 +1,81 @@
+from typing import Any, Optional
+
+from app.repositories._optional import OptionalModelRepository
+
+
+class NotificationRecordRepository(OptionalModelRepository):
+    """Persistence operations for notification records.
+
+    This repository expects a NotificationRecord model from the schema-worker
+    branch before its write methods can persist records.
+    """
+
+    model_name = "NotificationRecord"
+
+    def create(
+        self,
+        user_id: int,
+        notification_type: str,
+        channel: str,
+        query_id: Optional[Any] = None,
+        item_id: Optional[int] = None,
+        domain_event_id: Optional[int] = None,
+        status: str = "pending",
+        recipient: Optional[str] = None,
+        payload: Optional[dict[str, Any]] = None,
+        search_id: Optional[Any] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        **extra: Any,
+    ) -> Any:
+        """Create one notification record."""
+        normalized_query_id = self._query_id(query_id=query_id, search_id=search_id)
+        normalized_payload = payload if payload is not None else metadata
+        values = self.values(
+            user_id=user_id,
+            query_id=normalized_query_id,
+            item_id=item_id,
+            domain_event_id=domain_event_id,
+            notification_type=notification_type,
+            channel=channel,
+            status=status,
+            recipient=recipient,
+            payload=normalized_payload or {},
+            created_at=extra.pop("created_at", self.now()),
+            **extra,
+        )
+        return self.add(values)
+
+    def mark_sent(self, record: Any, sent_at: Optional[Any] = None) -> Any:
+        """Mark a notification as sent."""
+        self.update(record, self.values(status="sent", sent_at=sent_at or self.now()))
+        self.session.flush()
+        return record
+
+    def mark_failed(
+        self,
+        record: Any,
+        error_message: Optional[str] = None,
+        error: Optional[str] = None,
+    ) -> Any:
+        """Mark a notification as failed."""
+        values = self.values(
+            status="failed",
+            error_message=error_message or error,
+        )
+        self.update(record, values)
+        self.session.flush()
+        return record
+
+    def list_for_user(self, user_id: int, limit: int = 50) -> list[Any]:
+        """Return recent notification records for one user."""
+        return (
+            self.model.query.filter_by(user_id=user_id)
+            .order_by(self.model.created_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+    def _query_id(self, query_id: Optional[Any], search_id: Optional[Any]) -> Any:
+        if query_id is not None:
+            return query_id
+        return search_id

--- a/app/repositories/observations.py
+++ b/app/repositories/observations.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+from typing import Any, Optional
+
+from app.repositories._optional import OptionalModelRepository
+
+
+class ItemObservationRepository(OptionalModelRepository):
+    """Persistence operations for item observation snapshots.
+
+    This repository expects an ItemObservation model from the schema-worker
+    branch before its write methods can persist records.
+    """
+
+    model_name = "ItemObservation"
+
+    def create(
+        self,
+        item_id: int,
+        query_id: Optional[Any] = None,
+        observed_at: Optional[datetime] = None,
+        search_run_id: Optional[int] = None,
+        raw_item_snapshot: Optional[dict[str, Any]] = None,
+        search_id: Optional[Any] = None,
+        run_id: Optional[int] = None,
+        payload: Optional[dict[str, Any]] = None,
+        **extra: Any,
+    ) -> Any:
+        """Create one item observation snapshot."""
+        normalized_query_id = self._query_id(query_id=query_id, search_id=search_id)
+        normalized_run_id = self._search_run_id(
+            search_run_id=search_run_id, run_id=run_id
+        )
+        snapshot = raw_item_snapshot if raw_item_snapshot is not None else payload
+        values = self.values(
+            item_id=item_id,
+            query_id=normalized_query_id,
+            search_run_id=normalized_run_id,
+            observed_at=observed_at or self.now(),
+            raw_item_snapshot=snapshot or {},
+            **extra,
+        )
+        return self.add(values)
+
+    def latest_for_item(self, item_id: int) -> Any:
+        """Return the latest observation for an item."""
+        return (
+            self.model.query.filter_by(item_id=item_id)
+            .order_by(self.model.observed_at.desc())
+            .first()
+        )
+
+    def list_for_item(self, item_id: int, limit: int = 20) -> list[Any]:
+        """Return recent observations for an item."""
+        return (
+            self.model.query.filter_by(item_id=item_id)
+            .order_by(self.model.observed_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+    def _query_id(self, query_id: Optional[Any], search_id: Optional[Any]) -> Any:
+        if query_id is not None:
+            return query_id
+        if search_id is not None:
+            return search_id
+        raise ValueError("query_id is required")
+
+    def _search_run_id(
+        self,
+        search_run_id: Optional[int],
+        run_id: Optional[int],
+    ) -> Optional[int]:
+        if search_run_id is not None:
+            return search_run_id
+        return run_id
+
+    def list_for_query(self, query_id: Any, limit: int = 50) -> list[Any]:
+        """Return recent observations for a saved search."""
+        return (
+            self.model.query.filter_by(query_id=query_id)
+            .order_by(self.model.observed_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+    def list_for_run(self, search_run_id: int, limit: int = 100) -> list[Any]:
+        """Return observations captured by one search run."""
+        return (
+            self.model.query.filter_by(search_run_id=search_run_id)
+            .order_by(self.model.observed_at.desc())
+            .limit(limit)
+            .all()
+        )

--- a/app/repositories/queries.py
+++ b/app/repositories/queries.py
@@ -1,12 +1,88 @@
+from typing import Any, Optional
+
+from app.extensions import db
 from app.models import Keyword, UserQuery
 
 
+class KeywordRepository:
+    """Persistence operations for search keywords."""
+
+    def __init__(self, session: Optional[Any] = None):
+        self.session = session or db.session
+
+    def get(self, keyword_id: int) -> Optional[Keyword]:
+        """Return one keyword by id."""
+        return self.session.get(Keyword, keyword_id)
+
+    def find_by_text(self, keyword_text: str) -> Optional[Keyword]:
+        """Return the first keyword with matching text."""
+        return Keyword.query.filter_by(keyword_text=keyword_text).first()
+
+    def get_or_create(self, keyword_text: str) -> Keyword:
+        """Return an existing keyword or create one."""
+        keyword = self.find_by_text(keyword_text)
+        if keyword is not None:
+            return keyword
+
+        keyword = Keyword(keyword_text=keyword_text)
+        self.session.add(keyword)
+        self.session.flush()
+        return keyword
+
+
 class UserQueryRepository:
-    def get_active(self, query_id):
-        query = UserQuery.query.get(query_id)
+    """Persistence operations for saved searches backed by UserQuery."""
+
+    def __init__(self, session: Optional[Any] = None):
+        self.session = session or db.session
+        self.keywords = KeywordRepository(self.session)
+
+    def get(self, query_id: Any) -> Optional[UserQuery]:
+        """Return one saved search by id."""
+        return self.session.get(UserQuery, query_id)
+
+    def get_active(self, query_id: Any) -> Optional[UserQuery]:
+        """Return an active saved search or None."""
+        query = self.get(query_id)
         if not query or not query.is_active:
             return None
         return query
 
-    def get_keyword(self, keyword_id):
-        return Keyword.query.get(keyword_id)
+    def get_keyword(self, keyword_id: int) -> Optional[Keyword]:
+        """Return one keyword by id."""
+        return self.keywords.get(keyword_id)
+
+    def get_or_create_keyword(self, keyword_text: str) -> Keyword:
+        """Return an existing keyword or create one."""
+        return self.keywords.get_or_create(keyword_text)
+
+    def list_active(self) -> list[UserQuery]:
+        """Return all active saved searches."""
+        return UserQuery.query.filter_by(is_active=True).all()
+
+    def list_for_user(
+        self, user_id: int, include_inactive: bool = False
+    ) -> list[UserQuery]:
+        """Return saved searches owned by one user."""
+        query = UserQuery.query.filter_by(user_id=user_id)
+        if not include_inactive:
+            query = query.filter_by(is_active=True)
+        return query.all()
+
+    def create(
+        self,
+        user_id: int,
+        keyword_id: int,
+        marketplace: str = "EBAY_GB",
+        **values: Any,
+    ) -> UserQuery:
+        """Create a saved search record."""
+        saved_search = UserQuery(
+            user_id=user_id,
+            keyword_id=keyword_id,
+            marketplace=marketplace,
+            **values,
+        )
+        self.session.add(saved_search)
+        self.session.flush()
+        return saved_search

--- a/app/repositories/runs.py
+++ b/app/repositories/runs.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+from typing import Any, Optional
+
+from app.repositories._optional import OptionalModelRepository
+
+
+class SearchRunRepository(OptionalModelRepository):
+    """Persistence operations for search execution runs.
+
+    This repository expects a SearchRun model from the schema-worker branch
+    before its write methods can persist records.
+    """
+
+    model_name = "SearchRun"
+
+    def create(
+        self,
+        query_id: Optional[Any] = None,
+        run_type: str = "scheduled",
+        status: str = "started",
+        source: Optional[str] = None,
+        started_at: Optional[datetime] = None,
+        metadata_json: Optional[dict[str, Any]] = None,
+        search_id: Optional[Any] = None,
+        **extra: Any,
+    ) -> Any:
+        """Create one search run record."""
+        normalized_query_id = self._query_id(query_id=query_id, search_id=search_id)
+        values = self.values(
+            query_id=normalized_query_id,
+            run_type=run_type,
+            status=status,
+            source=source,
+            started_at=started_at or self.now(),
+            metadata_json=metadata_json or {},
+            **extra,
+        )
+        return self.add(values)
+
+    def mark_finished(
+        self,
+        run: Any,
+        status: str,
+        finished_at: Optional[datetime] = None,
+        error_message: Optional[str] = None,
+        **stats: Any,
+    ) -> Any:
+        """Mark a search run as finished."""
+        values = self.values(
+            status=status,
+            finished_at=finished_at or self.now(),
+            error_message=error_message,
+            **stats,
+        )
+        self.update(run, values)
+        self.session.flush()
+        return run
+
+    def list_recent(self, query_id: Any, limit: int = 20) -> list[Any]:
+        """Return recent runs for one saved search."""
+        return (
+            self.model.query.filter_by(query_id=query_id)
+            .order_by(self.model.started_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+    def _query_id(self, query_id: Optional[Any], search_id: Optional[Any]) -> Any:
+        if query_id is not None:
+            return query_id
+        if search_id is not None:
+            return search_id
+        raise ValueError("query_id is required")

--- a/app/tests/test_repository_wrappers.py
+++ b/app/tests/test_repository_wrappers.py
@@ -1,0 +1,509 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    Integer,
+    JSON,
+    Numeric,
+    String,
+    Text,
+)
+from sqlalchemy.orm import DeclarativeBase
+
+from app.repositories._models import RepositoryModelUnavailable
+from app.repositories.events import DomainEventRepository
+from app.repositories.features import ItemFeatureSnapshotRepository
+from app.repositories.interactions import InteractionRepository
+from app.repositories.notifications import NotificationRecordRepository
+from app.repositories.observations import ItemObservationRepository
+from app.repositories.runs import SearchRunRepository
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class SearchRun(Base):
+    __tablename__ = "test_search_runs"
+
+    search_run_id = Column(BigInteger, primary_key=True)
+    query_id = Column(String, nullable=False)
+    run_type = Column(String(30), nullable=False)
+    status = Column(String(30), nullable=False)
+    source = Column(String(50))
+    started_at = Column(DateTime, nullable=False)
+    finished_at = Column(DateTime)
+    items_seen = Column(Integer, nullable=False, default=0)
+    items_created = Column(Integer, nullable=False, default=0)
+    items_updated = Column(Integer, nullable=False, default=0)
+    error_message = Column(Text)
+    metadata_json = Column(JSON, nullable=False, default=dict)
+    created_at = Column(DateTime, nullable=False)
+
+
+class ItemObservation(Base):
+    __tablename__ = "test_item_observations"
+
+    item_observation_id = Column(BigInteger, primary_key=True)
+    search_run_id = Column(BigInteger)
+    query_id = Column(String, nullable=False)
+    item_id = Column(BigInteger, nullable=False)
+    observed_at = Column(DateTime, nullable=False)
+    price = Column(Numeric(10, 2))
+    currency = Column(String(10))
+    current_bid = Column(Numeric(10, 2))
+    condition = Column(String(50))
+    buying_options = Column(String(255))
+    listing_status = Column(String(50))
+    hard_filter_passed = Column(Boolean)
+    is_new_item = Column(Boolean, nullable=False, default=False)
+    raw_item_snapshot = Column(JSON, nullable=False, default=dict)
+    created_at = Column(DateTime, nullable=False)
+
+
+class UserItemInteraction(Base):
+    __tablename__ = "test_user_item_interactions"
+
+    user_item_interaction_id = Column(BigInteger, primary_key=True)
+    user_id = Column(Integer, nullable=False)
+    query_id = Column(String)
+    item_id = Column(BigInteger, nullable=False)
+    interaction_type = Column(String(40), nullable=False)
+    label = Column(String(40))
+    source = Column(String(50))
+    metadata_json = Column(JSON, nullable=False, default=dict)
+    created_at = Column(DateTime, nullable=False)
+
+
+class ItemFeatureSnapshot(Base):
+    __tablename__ = "test_item_feature_snapshots"
+
+    item_feature_snapshot_id = Column(BigInteger, primary_key=True)
+    query_id = Column(String, nullable=False)
+    item_id = Column(BigInteger, nullable=False)
+    search_run_id = Column(BigInteger)
+    feature_version = Column(String(40), nullable=False)
+    model_version = Column(String(80))
+    features = Column(JSON, nullable=False, default=dict)
+    relevance_score = Column(Float)
+    should_notify = Column(Boolean)
+    decision = Column(String(40))
+    created_at = Column(DateTime, nullable=False)
+
+
+class DomainEvent(Base):
+    __tablename__ = "test_domain_events"
+
+    domain_event_id = Column(BigInteger, primary_key=True)
+    event_type = Column(String(80), nullable=False)
+    aggregate_type = Column(String(50), nullable=False)
+    aggregate_id = Column(String(100), nullable=False)
+    user_id = Column(Integer)
+    query_id = Column(String)
+    item_id = Column(BigInteger)
+    status = Column(String(30), nullable=False)
+    source = Column(String(50))
+    payload = Column(JSON, nullable=False, default=dict)
+    occurred_at = Column(DateTime, nullable=False)
+    processed_at = Column(DateTime)
+    created_at = Column(DateTime, nullable=False)
+
+
+class NotificationRecord(Base):
+    __tablename__ = "test_notification_records"
+
+    notification_record_id = Column(BigInteger, primary_key=True)
+    domain_event_id = Column(BigInteger)
+    user_id = Column(Integer, nullable=False)
+    query_id = Column(String)
+    item_id = Column(BigInteger)
+    channel = Column(String(40), nullable=False)
+    notification_type = Column(String(60), nullable=False)
+    status = Column(String(30), nullable=False)
+    recipient = Column(String(255))
+    payload = Column(JSON, nullable=False, default=dict)
+    error_message = Column(Text)
+    sent_at = Column(DateTime)
+    created_at = Column(DateTime, nullable=False)
+
+
+class CaptureSession:
+    def __init__(self) -> None:
+        self.records: list[Any] = []
+        self.flush_count = 0
+
+    def add(self, record: Any) -> None:
+        self.records.append(record)
+
+    def flush(self) -> None:
+        self.flush_count += 1
+
+    def get(self, model: Any, record_id: Any) -> Any:
+        return SimpleNamespace(keyword_id=99)
+
+
+class QuerySpy:
+    def __init__(self) -> None:
+        self.filters: list[dict[str, Any]] = []
+        self.limit_value: Optional[int] = None
+
+    def filter_by(self, **filters: Any) -> "QuerySpy":
+        self.filters.append(filters)
+        return self
+
+    def order_by(self, *args: Any) -> "QuerySpy":
+        return self
+
+    def limit(self, value: int) -> "QuerySpy":
+        self.limit_value = value
+        return self
+
+    def all(self) -> list[str]:
+        return ["row"]
+
+    def first(self) -> str:
+        return "row"
+
+
+class FakeFeedbackRepository:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def record(self, **values: object) -> dict[str, object]:
+        self.calls.append(values)
+        return values
+
+
+@pytest.mark.parametrize(
+    ("repository", "method_name", "args"),
+    [
+        (SearchRunRepository(session=object()), "create", {"query_id": "query-1"}),
+        (
+            ItemObservationRepository(session=object()),
+            "create",
+            {"query_id": "query-1", "item_id": 1},
+        ),
+        (
+            DomainEventRepository(session=object()),
+            "create",
+            {
+                "event_type": "item.matched",
+                "aggregate_type": "saved_search",
+                "aggregate_id": "query-1",
+            },
+        ),
+        (
+            NotificationRecordRepository(session=object()),
+            "create",
+            {
+                "user_id": 1,
+                "query_id": "query-1",
+                "item_id": 2,
+                "notification_type": "new_item",
+                "channel": "telegram",
+            },
+        ),
+        (
+            ItemFeatureSnapshotRepository(session=object()),
+            "create",
+            {
+                "item_id": 2,
+                "query_id": "query-1",
+                "features": {"price": 12.5},
+            },
+        ),
+    ],
+)
+def test_future_schema_repositories_raise_clear_dependency_error(
+    repository,
+    method_name,
+    args,
+) -> None:
+    with pytest.raises(RepositoryModelUnavailable) as exc_info:
+        getattr(repository, method_name)(**args)
+
+    assert repository.model_name in str(exc_info.value)
+    assert "schema-worker model" in str(exc_info.value)
+
+
+def test_search_runs_use_schema_query_columns() -> None:
+    session = CaptureSession()
+    repository = SearchRunRepository(session=session, model=SearchRun)
+    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    record = repository.create(
+        query_id="query-1",
+        run_type="scheduled",
+        source="scheduler",
+        started_at=started_at,
+        items_seen=3,
+    )
+    repository.mark_finished(record, status="failed", error_message="timeout")
+
+    assert record.query_id == "query-1"
+    assert record.search_run_id is None
+    assert record.error_message == "timeout"
+    assert "search_id" not in record.__dict__
+
+
+def test_search_run_create_maps_search_id_alias_to_query_id() -> None:
+    repository = SearchRunRepository(session=CaptureSession(), model=SearchRun)
+
+    record = repository.create(search_id="query-1")
+
+    assert record.query_id == "query-1"
+    assert "search_id" not in record.__dict__
+
+
+def test_search_run_list_filters_by_query_id() -> None:
+    query = QuerySpy()
+    SearchRun.query = query
+
+    result = SearchRunRepository(session=object(), model=SearchRun).list_recent(
+        query_id="query-1", limit=5
+    )
+
+    assert result == ["row"]
+    assert query.filters == [{"query_id": "query-1"}]
+    assert query.limit_value == 5
+
+
+def test_item_observations_use_schema_snapshot_columns() -> None:
+    session = CaptureSession()
+    repository = ItemObservationRepository(session=session, model=ItemObservation)
+
+    record = repository.create(
+        query_id="query-1",
+        search_run_id=7,
+        item_id=2,
+        raw_item_snapshot={"title": "Camera"},
+        hard_filter_passed=True,
+        is_new_item=True,
+    )
+
+    assert record.query_id == "query-1"
+    assert record.search_run_id == 7
+    assert record.raw_item_snapshot == {"title": "Camera"}
+    assert "run_id" not in record.__dict__
+    assert "payload" not in record.__dict__
+
+
+def test_item_observation_create_maps_legacy_aliases() -> None:
+    repository = ItemObservationRepository(
+        session=CaptureSession(),
+        model=ItemObservation,
+    )
+
+    record = repository.create(
+        item_id=2,
+        search_id="query-1",
+        run_id=7,
+        payload={"title": "Camera"},
+    )
+
+    assert record.query_id == "query-1"
+    assert record.search_run_id == 7
+    assert record.raw_item_snapshot == {"title": "Camera"}
+    assert "search_id" not in record.__dict__
+    assert "run_id" not in record.__dict__
+    assert "payload" not in record.__dict__
+
+
+def test_item_observation_list_filters_by_search_run_id() -> None:
+    query = QuerySpy()
+    ItemObservation.query = query
+
+    result = ItemObservationRepository(
+        session=object(), model=ItemObservation
+    ).list_for_run(search_run_id=7, limit=10)
+
+    assert result == ["row"]
+    assert query.filters == [{"search_run_id": 7}]
+    assert query.limit_value == 10
+
+
+def test_feature_snapshots_use_query_and_run_columns() -> None:
+    session = CaptureSession()
+    repository = ItemFeatureSnapshotRepository(
+        session=session,
+        model=ItemFeatureSnapshot,
+    )
+
+    record = repository.create(
+        query_id="query-1",
+        search_run_id=7,
+        item_id=2,
+        features={"title_similarity": 0.8},
+        relevance_score=0.7,
+        should_notify=True,
+        decision="notify",
+    )
+
+    assert record.query_id == "query-1"
+    assert record.search_run_id == 7
+    assert record.feature_version == "v1"
+    assert "search_id" not in record.__dict__
+
+
+def test_feature_snapshot_create_maps_search_id_alias() -> None:
+    repository = ItemFeatureSnapshotRepository(
+        session=CaptureSession(),
+        model=ItemFeatureSnapshot,
+    )
+
+    record = repository.create(
+        search_id="query-1",
+        item_id=2,
+        features={"title_similarity": 0.8},
+    )
+
+    assert record.query_id == "query-1"
+    assert "search_id" not in record.__dict__
+
+
+def test_latest_for_search_item_filters_by_query_id() -> None:
+    query = QuerySpy()
+    ItemFeatureSnapshot.query = query
+
+    result = ItemFeatureSnapshotRepository(
+        session=object(), model=ItemFeatureSnapshot
+    ).latest_for_search_item(search_id="query-1", item_id=2)
+
+    assert result == "row"
+    assert query.filters == [{"query_id": "query-1", "item_id": 2}]
+
+
+def test_interactions_use_query_id_and_metadata_json() -> None:
+    session = CaptureSession()
+    repository = InteractionRepository(
+        session=session,
+        model=UserItemInteraction,
+    )
+
+    record = repository.record_interaction(
+        user_id=1,
+        query_id="query-1",
+        item_id=2,
+        interaction_type="feedback",
+        label="relevant",
+        source="details",
+        metadata_json={"source_item_rank": 1},
+    )
+
+    assert record.query_id == "query-1"
+    assert record.metadata_json == {"source_item_rank": 1}
+    assert "search_id" not in record.__dict__
+
+
+def test_interactions_map_search_id_and_metadata_aliases() -> None:
+    repository = InteractionRepository(
+        session=CaptureSession(),
+        model=UserItemInteraction,
+    )
+
+    record = repository.record_interaction(
+        user_id=1,
+        search_id="query-1",
+        item_id=2,
+        interaction_type="feedback",
+        metadata={"source_item_rank": 1},
+    )
+
+    assert record.query_id == "query-1"
+    assert record.metadata_json == {"source_item_rank": 1}
+    assert "search_id" not in record.__dict__
+    assert "metadata" not in record.__dict__
+
+
+def test_interaction_repository_falls_back_to_legacy_feedback() -> None:
+    feedback = FakeFeedbackRepository()
+    repository = InteractionRepository(
+        session=CaptureSession(),
+        feedback_repository=feedback,  # type: ignore[arg-type]
+    )
+
+    result = repository.record_interaction(
+        user_id=1,
+        query_id="query-1",
+        item_id=2,
+        interaction_type="dismissed",
+        label=None,
+        source="test",
+    )
+
+    assert result == {
+        "user_id": 1,
+        "item_id": 2,
+        "keyword_id": 99,
+        "is_relevant": False,
+    }
+    assert feedback.calls == [result]
+
+
+def test_notification_records_use_error_message_without_failed_at() -> None:
+    session = CaptureSession()
+    repository = NotificationRecordRepository(
+        session=session,
+        model=NotificationRecord,
+    )
+
+    record = repository.create(
+        user_id=1,
+        query_id="query-1",
+        item_id=2,
+        domain_event_id=3,
+        notification_type="new_item",
+        channel="telegram",
+        payload={"title": "Camera"},
+    )
+    repository.mark_failed(record, error_message="telegram timeout")
+
+    assert record.query_id == "query-1"
+    assert record.domain_event_id == 3
+    assert record.error_message == "telegram timeout"
+    assert "failed_at" not in record.__dict__
+    assert "error" not in record.__dict__
+
+
+def test_notification_records_map_legacy_aliases() -> None:
+    repository = NotificationRecordRepository(
+        session=CaptureSession(),
+        model=NotificationRecord,
+    )
+
+    record = repository.create(
+        user_id=1,
+        search_id="query-1",
+        notification_type="new_item",
+        channel="telegram",
+        metadata={"title": "Camera"},
+    )
+    repository.mark_failed(record, error="telegram timeout")
+
+    assert record.query_id == "query-1"
+    assert record.payload == {"title": "Camera"}
+    assert record.error_message == "telegram timeout"
+    assert "search_id" not in record.__dict__
+    assert "metadata" not in record.__dict__
+    assert "error" not in record.__dict__
+    assert "failed_at" not in record.__dict__
+
+
+def test_domain_events_list_pending_unprocessed_events() -> None:
+    query = QuerySpy()
+    DomainEvent.query = query
+
+    result = DomainEventRepository(
+        session=object(), model=DomainEvent
+    ).list_unprocessed(limit=25)
+
+    assert result == ["row"]
+    assert query.filters == [{"status": "pending", "processed_at": None}]
+    assert query.limit_value == 25


### PR DESCRIPTION
Closes #18

## Summary
- Adds focused repository classes for saved searches/keywords, global items, keyword-item links, search-item links, feedback/interactions, search runs, item observations, domain events, notification records, and item feature snapshots.
- Preserves the existing `ItemRepository` and `UserQueryRepository` facade methods used by current search processing.
- Aligns future schema-backed repositories with PR #63 model columns while keeping compatibility aliases for current callers.

## Schema Alignment From PR #63
- `SearchRunRepository` stores `query_id` and supports `search_id` as a create-time alias; `list_recent` filters by `query_id`.
- `ItemObservationRepository` stores `query_id`, `search_run_id`, `raw_item_snapshot`, `hard_filter_passed`, and `is_new_item`; aliases normalize `search_id -> query_id`, `run_id -> search_run_id`, and `payload -> raw_item_snapshot`.
- `ItemFeatureSnapshotRepository` stores `query_id`, `search_run_id`, `feature_version`, `model_version`, `features`, `relevance_score`, `should_notify`, and `decision`; `latest_for_search_item` filters via `query_id`.
- `InteractionRepository` stores `query_id` and `metadata_json`; aliases normalize `search_id -> query_id` and `metadata -> metadata_json`.
- `NotificationRecordRepository` stores `query_id`, `domain_event_id`, `payload`, `error_message`, and `sent_at`; aliases normalize `search_id -> query_id`, `metadata -> payload`, and `error -> error_message`; no `failed_at` is set.
- `DomainEventRepository` includes `status`, `source`, `payload`, `occurred_at`, and `processed_at`; unprocessed listing filters pending, unprocessed events.

## Files Changed
- `app/repositories/__init__.py`
- `app/repositories/_models.py`
- `app/repositories/_optional.py`
- `app/repositories/items.py`
- `app/repositories/queries.py`
- `app/repositories/interactions.py`
- `app/repositories/runs.py`
- `app/repositories/observations.py`
- `app/repositories/events.py`
- `app/repositories/notifications.py`
- `app/repositories/features.py`
- `app/tests/test_repository_wrappers.py`

## Migrations
- None.

## Preserved Behavior
- Existing `ItemRepository` methods remain available: `get_by_ebay_id`, `get_feedback`, `create_item`, `link_keyword`, `link_query`, `get_query_item`, and `update_item`.
- Existing `UserQueryRepository.get_active` and `get_keyword` remain available.
- No changes to `ebay_client/**`, models, migrations, routes, jobs, relevance services, notifications services, or search services.

## New Behavior
- New narrow repository classes provide explicit DB access boundaries for current and planned persistence areas.
- Future schema-backed repositories document their model dependency and raise a clear runtime error if used before the schema exists.
- Focused tests use concrete fake SQLAlchemy models with the PR #63 column names and verify alias normalization does not leak legacy field names to model constructors.

## Validation
- `/tmp/coco-search-cs18-venv/bin/pytest app/tests/test_repository_wrappers.py` passed: 20 tests.
- `python3.10 -m compileall app ebay_client config.py` passed.
- `git diff --check` passed.
- `/tmp/coco-search-cs18-venv/bin/pytest` was run but still fails during existing collection issues: missing `Query` model imports, missing `archive_items`/`load_historical_items`, missing `cancel_subscription_logic`, and missing `ENCRYPTION_KEY`.
- `/tmp/coco-search-cs18-venv/bin/black .` was run; it reformatted many out-of-scope files including `ebay_client/**`, so that formatter churn was reverted and only owned files remain changed.
- `/tmp/coco-search-cs18-venv/bin/mypy .` was run but still fails on existing project-wide missing stubs/model typing and stale tests; no repository-wrapper errors remain in the reported output.

## Risks / Open Questions
- These wrappers are aligned to PR #63 as currently proposed. If PR #63 changes column names before merge, this PR will need a small follow-up alignment patch.