### PR TITLE
feat: add search domain primitives

### DIFF
--- a/app/searches/__init__.py
+++ b/app/searches/__init__.py
@@ -1,10 +1,22 @@
+from app.searches.definitions import SavedSearch, SearchFilters, SearchSchedule
 from app.searches.execution import EbaySearchExecutor, scrape_ebay, scrape_new_items
 from app.searches.item_processor import SearchItemProcessor, process_items
+from app.searches.mapping import saved_search_from_model, to_ebay_search_params
+from app.searches.onboarding import SearchOnboardingService
+from app.searches.validation import ensure_valid_saved_search, validate_saved_search
 
 __all__ = [
     "EbaySearchExecutor",
+    "SavedSearch",
+    "SearchFilters",
+    "SearchOnboardingService",
+    "SearchSchedule",
     "SearchItemProcessor",
+    "ensure_valid_saved_search",
     "process_items",
+    "saved_search_from_model",
     "scrape_ebay",
     "scrape_new_items",
+    "to_ebay_search_params",
+    "validate_saved_search",
 ]

--- a/app/searches/definitions.py
+++ b/app/searches/definitions.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class SearchFilters:
+    """Hard filters and legacy keyword gates for a saved search."""
+
+    min_price: Optional[Decimal] = None
+    max_price: Optional[Decimal] = None
+    item_location: Optional[str] = "GB"
+    condition: Optional[str] = None
+    buying_options: str = "FIXED_PRICE|AUCTION"
+    required_keywords: Optional[str] = None
+    excluded_keywords: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class SearchSchedule:
+    """Scheduling state for recurring search execution."""
+
+    check_interval: int = 5
+    first_run: bool = True
+    last_full_run: Optional[datetime] = None
+    next_full_run: Optional[datetime] = None
+    last_recent_run: Optional[datetime] = None
+
+
+@dataclass(frozen=True)
+class SavedSearch:
+    """Domain representation of a user's saved eBay search."""
+
+    id: str
+    user_id: int
+    keyword_id: int
+    keywords: str
+    marketplace: str
+    is_active: bool
+    filters: SearchFilters
+    schedule: SearchSchedule

--- a/app/searches/execution.py
+++ b/app/searches/execution.py
@@ -1,34 +1,38 @@
 from threading import local
+from typing import Any, Callable, Optional
 
 from circuitbreaker import circuit
 
 from ebay_client import EbayClient
+from app.searches.definitions import SavedSearch
+from app.searches.mapping import to_ebay_search_params
 from app.utils.text_helpers import filter_items_by_keywords
-
 
 _thread_local = local()
 
 
-def create_ebay_client():
+def create_ebay_client() -> EbayClient:
     if not hasattr(_thread_local, "ebay_client"):
         _thread_local.ebay_client = EbayClient()
     return _thread_local.ebay_client
 
 
 class EbaySearchExecutor:
-    def __init__(self, api_factory=create_ebay_client):
+    def __init__(
+        self, api_factory: Callable[[], EbayClient] = create_ebay_client
+    ) -> None:
         self.api_factory = api_factory
 
     def execute(
         self,
-        keywords,
-        filters=None,
-        marketplace="EBAY_GB",
-        required_keywords=None,
-        excluded_keywords=None,
-        sort_order="newlyListed",
-        max_pages=1,
-    ):
+        keywords: str,
+        filters: Optional[dict[str, Any]] = None,
+        marketplace: str = "EBAY_GB",
+        required_keywords: Optional[str] = None,
+        excluded_keywords: Optional[str] = None,
+        sort_order: str = "newlyListed",
+        max_pages: int = 1,
+    ) -> list[dict[str, Any]]:
         api = self.api_factory()
         items = api.search_items(
             keywords=keywords,
@@ -38,6 +42,23 @@ class EbaySearchExecutor:
             marketplace=marketplace,
         )
         return filter_items_by_keywords(items, required_keywords, excluded_keywords)
+
+    def execute_saved_search(
+        self,
+        saved_search: SavedSearch,
+        sort_order: str = "newlyListed",
+        max_pages: int = 1,
+    ) -> list[dict[str, Any]]:
+        params = to_ebay_search_params(saved_search)
+        return self.execute(
+            keywords=params["keywords"],
+            filters=params["filters"],
+            marketplace=params["marketplace"],
+            required_keywords=saved_search.filters.required_keywords,
+            excluded_keywords=saved_search.filters.excluded_keywords,
+            sort_order=sort_order,
+            max_pages=max_pages,
+        )
 
 
 @circuit(failure_threshold=3, recovery_timeout=60)

--- a/app/searches/mapping.py
+++ b/app/searches/mapping.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Optional
+
+from app.searches.definitions import SavedSearch, SearchFilters, SearchSchedule
+
+
+def saved_search_from_model(user_query: Any) -> SavedSearch:
+    """Map a UserQuery ORM object to a SavedSearch domain object."""
+
+    keywords = _keywords_for_query(user_query)
+    saved_search = SavedSearch(
+        id=str(user_query.query_id),
+        user_id=int(user_query.user_id),
+        keyword_id=int(user_query.keyword_id),
+        keywords=keywords,
+        marketplace=user_query.marketplace or "EBAY_GB",
+        is_active=bool(user_query.is_active),
+        filters=SearchFilters(
+            min_price=_optional_decimal(user_query.min_price),
+            max_price=_optional_decimal(user_query.max_price),
+            item_location=user_query.item_location,
+            condition=user_query.condition,
+            buying_options=user_query.buying_options or "FIXED_PRICE|AUCTION",
+            required_keywords=user_query.required_keywords,
+            excluded_keywords=user_query.excluded_keywords,
+        ),
+        schedule=SearchSchedule(
+            check_interval=int(user_query.check_interval or 5),
+            first_run=bool(user_query.first_run),
+            last_full_run=user_query.last_full_run,
+            next_full_run=user_query.next_full_run,
+            last_recent_run=user_query.last_recent_run,
+        ),
+    )
+    return saved_search
+
+
+def to_ebay_search_params(saved_search: SavedSearch) -> dict[str, Any]:
+    """Return public EbayClient search parameters for a saved search."""
+
+    return {
+        "keywords": saved_search.keywords,
+        "filters": {
+            "min_price": _decimal_to_float(saved_search.filters.min_price),
+            "max_price": _decimal_to_float(saved_search.filters.max_price),
+            "item_location": saved_search.filters.item_location,
+            "condition": saved_search.filters.condition,
+            "buying_options": saved_search.filters.buying_options,
+        },
+        "marketplace": saved_search.marketplace,
+    }
+
+
+def _keywords_for_query(user_query: Any) -> str:
+    keyword = getattr(user_query, "keyword", None)
+    if keyword is not None and getattr(keyword, "keyword_text", None):
+        return str(keyword.keyword_text)
+    if getattr(user_query, "keywords", None):
+        return str(user_query.keywords)
+    raise ValueError("Saved search requires keyword text")
+
+
+def _optional_decimal(value: Any) -> Optional[Decimal]:
+    if value is None:
+        return None
+    return Decimal(str(value))
+
+
+def _decimal_to_float(value: Optional[Decimal]) -> Optional[float]:
+    if value is None:
+        return None
+    return float(value)

--- a/app/searches/onboarding.py
+++ b/app/searches/onboarding.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from app.searches.definitions import SavedSearch
+from app.searches.execution import create_ebay_client
+from app.searches.mapping import to_ebay_search_params
+from app.searches.sampling import diverse_items
+from app.searches.validation import ensure_valid_saved_search
+from app.utils.text_helpers import filter_items_by_keywords
+
+DEFAULT_PREVIEW_LIMIT = 20
+MAX_CANDIDATES = 100
+
+
+class EbayPreviewClient(Protocol):
+    """Public eBay client methods used for onboarding previews."""
+
+    def search_item_summaries(
+        self,
+        keywords: str,
+        filters: dict[str, Any] | None = None,
+        limit: int = MAX_CANDIDATES,
+        offset: int = 0,
+        sort_order: str | None = None,
+        marketplace: str | None = None,
+    ) -> dict[str, Any]:
+        """Fetch raw item summaries from eBay."""
+        ...
+
+    def parse_item_summary_response(
+        self, response: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Parse eBay item summaries into app item dictionaries."""
+        ...
+
+
+class SearchOnboardingService:
+    """Build labelled-training previews for saved searches."""
+
+    def __init__(self, ebay_client_factory=create_ebay_client) -> None:
+        self.ebay_client_factory = ebay_client_factory
+
+    def create_preview(
+        self, saved_search: SavedSearch, limit: int = DEFAULT_PREVIEW_LIMIT
+    ) -> list[dict[str, Any]]:
+        """Return diverse candidate dicts ready for likely/not-likely labels."""
+
+        ensure_valid_saved_search(saved_search)
+        if limit <= 0:
+            return []
+
+        candidate_limit = _candidate_limit(limit)
+        candidates = self._fetch_candidates(saved_search, candidate_limit)
+        filtered = filter_items_by_keywords(
+            candidates,
+            saved_search.filters.required_keywords,
+            saved_search.filters.excluded_keywords,
+        )
+        selected = diverse_items(filtered, limit)
+        return [_preview_item(saved_search.id, item) for item in selected]
+
+    def _fetch_candidates(
+        self, saved_search: SavedSearch, candidate_limit: int
+    ) -> list[dict[str, Any]]:
+        client = self.ebay_client_factory()
+        params = to_ebay_search_params(saved_search)
+        raw_response = client.search_item_summaries(
+            keywords=params["keywords"],
+            filters=params["filters"],
+            limit=candidate_limit,
+            offset=0,
+            sort_order="newlyListed",
+            marketplace=params["marketplace"],
+        )
+        return client.parse_item_summary_response(raw_response)
+
+
+def _candidate_limit(limit: int) -> int:
+    if limit <= 0:
+        return 0
+    return min(max(limit * 5, limit), MAX_CANDIDATES)
+
+
+def _preview_item(search_id: str, item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "search_id": search_id,
+        "item_id": item.get("ebay_id") or item.get("item_id"),
+        "title": item.get("title"),
+        "price": item.get("price"),
+        "currency": item.get("currency"),
+        "condition": item.get("condition"),
+        "location": item.get("location"),
+        "buying_options": item.get("buying_options"),
+        "url": item.get("url"),
+        "image_url": item.get("image_url"),
+        "seller": item.get("seller"),
+        "likely_to_buy": None,
+        "not_likely_to_buy": None,
+    }

--- a/app/searches/sampling.py
+++ b/app/searches/sampling.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+from decimal import Decimal, InvalidOperation
+from difflib import SequenceMatcher
+from typing import Any, Optional
+
+NEAR_DUPLICATE_THRESHOLD = 0.86
+
+
+def diverse_items(items: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    """Select diverse items while avoiding near-duplicate titles."""
+
+    if limit <= 0:
+        return []
+
+    selected: list[dict[str, Any]] = []
+    remaining = list(items)
+    price_bands = _price_bands(items)
+
+    while remaining and len(selected) < limit:
+        best = _best_candidate(remaining, selected, price_bands)
+        if best is None:
+            break
+        selected.append(best)
+        remaining.remove(best)
+
+    return selected
+
+
+def _best_candidate(
+    candidates: list[dict[str, Any]],
+    selected: list[dict[str, Any]],
+    price_bands: dict[int, str],
+) -> Optional[dict[str, Any]]:
+    selected_titles = [_normalized_title(item) for item in selected]
+    selectable = [
+        item
+        for item in candidates
+        if not _is_near_duplicate(_normalized_title(item), selected_titles)
+    ]
+    if not selectable:
+        return None
+
+    condition_counts = Counter(_condition(item) for item in selected)
+    location_counts = Counter(_location(item) for item in selected)
+    price_band_counts = Counter(_price_band(item, price_bands) for item in selected)
+
+    return max(
+        selectable,
+        key=lambda item: (
+            _rarity_score(_condition(item), condition_counts),
+            _rarity_score(_location(item), location_counts),
+            _rarity_score(_price_band(item, price_bands), price_band_counts),
+            -candidates.index(item),
+        ),
+    )
+
+
+def _rarity_score(value: str, counts: Counter[str]) -> int:
+    if value == "unknown":
+        return 0
+    return -counts[value]
+
+
+def _normalized_title(item: dict[str, Any]) -> str:
+    title = str(item.get("title") or "").lower()
+    return re.sub(r"\W+", " ", title).strip()
+
+
+def _is_near_duplicate(title: str, selected_titles: list[str]) -> bool:
+    if not title:
+        return False
+    return any(
+        SequenceMatcher(None, title, selected_title).ratio() >= NEAR_DUPLICATE_THRESHOLD
+        for selected_title in selected_titles
+    )
+
+
+def _condition(item: dict[str, Any]) -> str:
+    return str(item.get("condition") or "unknown").lower()
+
+
+def _location(item: dict[str, Any]) -> str:
+    location = item.get("location")
+    if isinstance(location, dict):
+        return str(location.get("country") or "unknown").lower()
+    return str(location or item.get("item_location") or "unknown").lower()
+
+
+def _price_band(item: dict[str, Any], price_bands: dict[int, str]) -> str:
+    return price_bands.get(id(item), "unknown")
+
+
+def _price_bands(items: list[dict[str, Any]]) -> dict[int, str]:
+    prices = sorted(
+        price for price in (_price(item) for item in items) if price is not None
+    )
+    if not prices:
+        return {}
+
+    low_cutoff = prices[len(prices) // 3]
+    high_cutoff = prices[(len(prices) * 2) // 3]
+    bands = {}
+    for item in items:
+        price = _price(item)
+        if price is None:
+            bands[id(item)] = "unknown"
+        elif price <= low_cutoff:
+            bands[id(item)] = "low"
+        elif price <= high_cutoff:
+            bands[id(item)] = "mid"
+        else:
+            bands[id(item)] = "high"
+    return bands
+
+
+def _price(item: dict[str, Any]) -> Optional[Decimal]:
+    value = item.get("price")
+    if isinstance(value, dict):
+        value = value.get("value")
+    try:
+        return Decimal(str(value)) if value not in (None, "") else None
+    except (InvalidOperation, TypeError):
+        return None

--- a/app/searches/validation.py
+++ b/app/searches/validation.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from app.searches.definitions import SavedSearch, SearchFilters, SearchSchedule
+
+MIN_CHECK_INTERVAL_MINUTES = 5
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """A structured validation failure for search-domain objects."""
+
+    field: str
+    message: str
+
+
+class SearchValidationError(ValueError):
+    """Raised when a search-domain object fails validation."""
+
+    def __init__(self, issues: list[ValidationIssue]) -> None:
+        self.issues = issues
+        message = "; ".join(f"{issue.field}: {issue.message}" for issue in issues)
+        super().__init__(message)
+
+
+def validate_search_schedule(schedule: SearchSchedule) -> list[ValidationIssue]:
+    """Return validation issues for a search schedule."""
+
+    issues: list[ValidationIssue] = []
+    if schedule.check_interval < MIN_CHECK_INTERVAL_MINUTES:
+        issues.append(
+            ValidationIssue(
+                field="schedule.check_interval",
+                message="must be at least 5 minutes",
+            )
+        )
+    return issues
+
+
+def validate_search_filters(filters: SearchFilters) -> list[ValidationIssue]:
+    """Return validation issues for search filters."""
+
+    issues: list[ValidationIssue] = []
+    if (
+        filters.min_price is not None
+        and filters.max_price is not None
+        and Decimal(filters.min_price) > Decimal(filters.max_price)
+    ):
+        issues.append(
+            ValidationIssue(
+                field="filters.max_price",
+                message="must be greater than or equal to min_price",
+            )
+        )
+    return issues
+
+
+def validate_saved_search(saved_search: SavedSearch) -> list[ValidationIssue]:
+    """Return validation issues for a saved search."""
+
+    issues = []
+    if not saved_search.keywords.strip():
+        issues.append(ValidationIssue(field="keywords", message="must not be blank"))
+    if not saved_search.marketplace.strip():
+        issues.append(ValidationIssue(field="marketplace", message="must not be blank"))
+
+    issues.extend(validate_search_filters(saved_search.filters))
+    issues.extend(validate_search_schedule(saved_search.schedule))
+    return issues
+
+
+def ensure_valid_saved_search(saved_search: SavedSearch) -> None:
+    """Raise SearchValidationError when a saved search is invalid."""
+
+    issues = validate_saved_search(saved_search)
+    if issues:
+        raise SearchValidationError(issues)

--- a/app/tests/test_search_domain.py
+++ b/app/tests/test_search_domain.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from app.searches.definitions import SavedSearch, SearchFilters, SearchSchedule
+from app.searches.mapping import saved_search_from_model, to_ebay_search_params
+from app.searches.validation import SearchValidationError, ensure_valid_saved_search
+
+
+@dataclass
+class KeywordStub:
+    keyword_text: str
+
+
+@dataclass
+class UserQueryStub:
+    query_id: str
+    user_id: int
+    keyword_id: int
+    keyword: KeywordStub
+    marketplace: str
+    is_active: bool
+    min_price: Decimal | None
+    max_price: Decimal | None
+    item_location: str
+    condition: str
+    buying_options: str
+    required_keywords: str
+    excluded_keywords: str
+    check_interval: int
+    first_run: bool
+    last_full_run: datetime | None
+    next_full_run: datetime | None
+    last_recent_run: datetime | None
+
+
+def test_saved_search_from_model_maps_query_fields() -> None:
+    last_full_run = datetime(2026, 4, 28, tzinfo=timezone.utc)
+    query = UserQueryStub(
+        query_id="search-1",
+        user_id=7,
+        keyword_id=11,
+        keyword=KeywordStub(keyword_text="sony camera"),
+        marketplace="EBAY_GB",
+        is_active=True,
+        min_price=Decimal("10.50"),
+        max_price=Decimal("250.00"),
+        item_location="GB",
+        condition="USED",
+        buying_options="AUCTION",
+        required_keywords="sony",
+        excluded_keywords="broken",
+        check_interval=15,
+        first_run=False,
+        last_full_run=last_full_run,
+        next_full_run=None,
+        last_recent_run=None,
+    )
+
+    saved_search = saved_search_from_model(query)
+
+    assert saved_search == SavedSearch(
+        id="search-1",
+        user_id=7,
+        keyword_id=11,
+        keywords="sony camera",
+        marketplace="EBAY_GB",
+        is_active=True,
+        filters=SearchFilters(
+            min_price=Decimal("10.50"),
+            max_price=Decimal("250.00"),
+            item_location="GB",
+            condition="USED",
+            buying_options="AUCTION",
+            required_keywords="sony",
+            excluded_keywords="broken",
+        ),
+        schedule=SearchSchedule(
+            check_interval=15,
+            first_run=False,
+            last_full_run=last_full_run,
+            next_full_run=None,
+            last_recent_run=None,
+        ),
+    )
+
+
+def test_to_ebay_search_params_uses_sdk_filter_shape() -> None:
+    saved_search = SavedSearch(
+        id="search-1",
+        user_id=7,
+        keyword_id=11,
+        keywords="sony camera",
+        marketplace="EBAY_GB",
+        is_active=True,
+        filters=SearchFilters(
+            min_price=Decimal("10.50"),
+            max_price=Decimal("250.00"),
+            item_location="GB",
+            condition="USED",
+            buying_options="AUCTION",
+            required_keywords="sony",
+            excluded_keywords="broken",
+        ),
+        schedule=SearchSchedule(check_interval=5),
+    )
+
+    params = to_ebay_search_params(saved_search)
+
+    assert params == {
+        "keywords": "sony camera",
+        "filters": {
+            "min_price": 10.5,
+            "max_price": 250.0,
+            "item_location": "GB",
+            "condition": "USED",
+            "buying_options": "AUCTION",
+        },
+        "marketplace": "EBAY_GB",
+    }
+
+
+def test_validation_rejects_intervals_below_five_minutes() -> None:
+    saved_search = SavedSearch(
+        id="search-1",
+        user_id=7,
+        keyword_id=11,
+        keywords="sony camera",
+        marketplace="EBAY_GB",
+        is_active=True,
+        filters=SearchFilters(),
+        schedule=SearchSchedule(check_interval=4),
+    )
+
+    with pytest.raises(SearchValidationError) as exc_info:
+        ensure_valid_saved_search(saved_search)
+
+    assert "schedule.check_interval: must be at least 5 minutes" in str(exc_info.value)

--- a/app/tests/test_search_onboarding.py
+++ b/app/tests/test_search_onboarding.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+
+from app.searches.definitions import SavedSearch, SearchFilters, SearchSchedule
+from app.searches.onboarding import SearchOnboardingService
+
+
+@dataclass
+class FakeEbayClient:
+    items: list[dict[str, Any]]
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def search_item_summaries(
+        self,
+        keywords: str,
+        filters: dict[str, Any] | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        sort_order: str | None = None,
+        marketplace: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "keywords": keywords,
+                "filters": filters,
+                "limit": limit,
+                "offset": offset,
+                "sort_order": sort_order,
+                "marketplace": marketplace,
+            }
+        )
+        return {"items": self.items[:limit]}
+
+    def parse_item_summary_response(
+        self, response: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        return list(response["items"])
+
+
+def test_create_preview_filters_legacy_keywords_and_labels_items() -> None:
+    fake_client = FakeEbayClient(
+        items=[
+            _item("1", "Sony Alpha camera body", 100, "USED", "GB"),
+            _item("2", "Sony Alpha camera body boxed", 110, "USED", "GB"),
+            _item("3", "Sony Alpha camera lens", 300, "NEW", "US"),
+            _item("4", "Sony Alpha camera broken", 50, "USED", "GB"),
+            _item("5", "Canon camera body", 150, "USED", "GB"),
+            _item("6", "Sony Alpha camera kit", 500, "NEW", "DE"),
+        ]
+    )
+    service = SearchOnboardingService(ebay_client_factory=lambda: fake_client)
+
+    preview = service.create_preview(_saved_search(), limit=3)
+
+    assert fake_client.calls[0]["limit"] == 15
+    assert fake_client.calls[0]["marketplace"] == "EBAY_GB"
+    assert [item["item_id"] for item in preview] == ["1", "3", "6"]
+    assert all(item["likely_to_buy"] is None for item in preview)
+    assert all(item["not_likely_to_buy"] is None for item in preview)
+
+
+def test_create_preview_fetches_at_most_one_hundred_candidates() -> None:
+    fake_client = FakeEbayClient(
+        items=[
+            _item(str(index), f"Sony camera {index}", index, "USED", "GB")
+            for index in range(150)
+        ]
+    )
+    service = SearchOnboardingService(ebay_client_factory=lambda: fake_client)
+
+    service.create_preview(_saved_search(), limit=25)
+
+    assert fake_client.calls[0]["limit"] == 100
+
+
+def _saved_search() -> SavedSearch:
+    return SavedSearch(
+        id="search-1",
+        user_id=7,
+        keyword_id=11,
+        keywords="sony camera",
+        marketplace="EBAY_GB",
+        is_active=True,
+        filters=SearchFilters(
+            min_price=Decimal("50"),
+            max_price=Decimal("500"),
+            item_location="GB",
+            condition="USED",
+            buying_options="FIXED_PRICE|AUCTION",
+            required_keywords="sony, camera",
+            excluded_keywords="broken, canon",
+        ),
+        schedule=SearchSchedule(check_interval=5),
+    )
+
+
+def _item(
+    item_id: str,
+    title: str,
+    price: int,
+    condition: str,
+    country: str,
+) -> dict[str, Any]:
+    return {
+        "ebay_id": item_id,
+        "title": title,
+        "price": price,
+        "currency": "GBP",
+        "condition": condition,
+        "location": {"country": country},
+        "buying_options": "FIXED_PRICE",
+        "url": f"https://example.test/{item_id}",
+        "image_url": f"https://example.test/{item_id}.jpg",
+        "seller": "seller",
+    }


### PR DESCRIPTION
## Summary

Closes #17.

Adds the shared search-domain layer for saved searches, including dataclasses for filters, schedule, and saved search identity. Adds mapping from existing `UserQuery` model objects into the domain object and conversion back to public `EbayClient` search parameters.

Adds validation for saved searches, including the minimum 5-minute schedule interval, and implements onboarding preview generation that fetches extra candidates, applies legacy required/excluded keyword hard filters, avoids near-duplicate titles, and selects a more diverse sample across price band, condition, and location.

## Files changed

- `app/searches/definitions.py`
- `app/searches/mapping.py`
- `app/searches/validation.py`
- `app/searches/sampling.py`
- `app/searches/onboarding.py`
- `app/searches/execution.py`
- `app/searches/__init__.py`
- `app/tests/test_search_domain.py`
- `app/tests/test_search_onboarding.py`

## Migrations

None.

## Preserved behavior

- Existing `scrape_ebay` and `scrape_new_items` names and call signatures are preserved.
- Legacy `required_keywords` and `excluded_keywords` remain hard filters after eBay candidate fetches.
- eBay SDK access stays behind public `EbayClient` methods only.
- `ebay_client/**`, models, routes, repositories, relevance, notifications, jobs, and migrations are not changed.

## New behavior

- `saved_search_from_model(user_query)` produces a `SavedSearch` domain object.
- `to_ebay_search_params(saved_search)` returns SDK-ready keyword/filter/marketplace params.
- `SearchOnboardingService.create_preview(...)` returns label-ready preview dicts with `likely_to_buy` and `not_likely_to_buy` placeholders.
- `EbaySearchExecutor.execute_saved_search(...)` can execute the shared domain object while preserving legacy keyword gates.

## Tests and checks

- Passed: `python3 -m compileall app ebay_client config.py`
- Passed: `/tmp/coco-search-cs-17-venv/bin/pytest --noconftest app/tests/test_search_domain.py app/tests/test_search_onboarding.py`
- Passed: `/tmp/coco-search-cs-17-venv/bin/black --check app/searches/definitions.py app/searches/mapping.py app/searches/validation.py app/searches/sampling.py app/searches/onboarding.py app/searches/execution.py app/searches/__init__.py app/tests/test_search_domain.py app/tests/test_search_onboarding.py`
- Ran: `/tmp/coco-search-cs-17-venv/bin/black .`; it reformatted unrelated files, so those formatter-only edits were restored to keep this PR within ownership.
- Failed in local environment: `/tmp/coco-search-cs-17-venv/bin/pytest` during collection due existing repo/environment issues: missing `Query` model imports in legacy tests, missing optional packages (`pandas`, `stripe`), and missing `ENCRYPTION_KEY`.
- Failed in local environment: `/tmp/coco-search-cs-17-venv/bin/mypy .` due existing missing stubs/packages and existing model/test typing issues.

## Risks / open questions

- Preview diversity is heuristic-based; future relevance work may replace or tune price/condition/location weighting.
- Local verification used Python 3.14 because Python 3.11 was unavailable on this machine; the app runtime remains Python 3.11.8.