### PR TITLE
[codex] Add item processing domain events

### DIFF
--- a/app/items/normalization.py
+++ b/app/items/normalization.py
@@ -1,0 +1,170 @@
+"""Normalize item payloads from eBay SDK responses for storage."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+
+
+def normalize_item_payload(item_data: dict[str, Any]) -> dict[str, Any]:
+    """Return a storage-ready item payload from parsed or raw SDK item data."""
+    price = _money_value(item_data.get("price"))
+    current_bid_source = item_data.get("current_bid", item_data.get("currentBidPrice"))
+    current_bid = _money_value(current_bid_source)
+    currency = _money_currency(item_data.get("price")) or item_data.get("currency")
+    current_bid_currency = _money_currency(
+        item_data.get("currentBidPrice")
+    ) or item_data.get("current_bid_currency")
+    location = _location(item_data)
+    buying_options = item_data.get("buying_options", item_data.get("buyingOptions"))
+
+    normalized = {
+        "ebay_id": item_data.get("ebay_id") or item_data.get("itemId"),
+        "legacy_id": item_data.get("legacy_id") or item_data.get("legacyItemId"),
+        "title": item_data.get("title"),
+        "price": price,
+        "current_bid": current_bid,
+        "current_bid_currency": current_bid_currency,
+        "currency": currency,
+        "url": item_data.get("url") or item_data.get("itemWebUrl"),
+        "image_url": _image_url(item_data),
+        "seller": _seller(item_data),
+        "seller_rating": _seller_rating(item_data),
+        "condition": item_data.get("condition"),
+        "location": location,
+        "location_country": location.get("country"),
+        "postal_code": location.get("postal_code"),
+        "start_time": _datetime_value(
+            item_data.get("start_time") or item_data.get("itemCreationDate")
+        ),
+        "end_time": _datetime_value(
+            item_data.get("end_time") or item_data.get("itemEndDate")
+        ),
+        "buying_options": _json_text(buying_options),
+        "auction_details": _auction_details(item_data, buying_options),
+        "categories": _categories(item_data),
+        "marketplace": item_data.get("marketplace")
+        or item_data.get("marketplace_id")
+        or item_data.get("listingMarketplaceId"),
+        "images": _images(item_data),
+    }
+
+    return {key: value for key, value in normalized.items() if value is not None}
+
+
+def _money_value(value: Any) -> float | None:
+    if isinstance(value, dict):
+        value = value.get("value")
+    if value in (None, ""):
+        return None
+    return float(value)
+
+
+def _money_currency(value: Any) -> str | None:
+    if isinstance(value, dict):
+        return value.get("currency")
+    return None
+
+
+def _datetime_value(value: Any) -> datetime | None:
+    if isinstance(value, datetime) or value is None:
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return None
+
+
+def _location(item_data: dict[str, Any]) -> dict[str, Any]:
+    location = item_data.get("location") or item_data.get("itemLocation") or {}
+    return {
+        "country": location.get("country"),
+        "postal_code": location.get("postal_code") or location.get("postalCode"),
+    }
+
+
+def _image_url(item_data: dict[str, Any]) -> str | None:
+    image = item_data.get("image") or {}
+    return item_data.get("image_url") or image.get("imageUrl")
+
+
+def _seller(item_data: dict[str, Any]) -> str | None:
+    seller = item_data.get("seller")
+    if isinstance(seller, dict):
+        return seller.get("username")
+    return seller
+
+
+def _seller_rating(item_data: dict[str, Any]) -> Any:
+    seller = item_data.get("seller")
+    if isinstance(seller, dict):
+        return seller.get("feedbackPercentage")
+    return item_data.get("seller_rating")
+
+
+def _auction_details(item_data: dict[str, Any], buying_options: Any) -> str | None:
+    if item_data.get("auction_details"):
+        return _json_text(item_data["auction_details"])
+    if "AUCTION" not in _buying_options_list(buying_options):
+        return None
+
+    current_bid_price = item_data.get("currentBidPrice", {})
+    current_bid_currency = (
+        _money_currency(current_bid_price) or item_data.get("currency") or "GBP"
+    )
+    auction_data = {
+        "bid_count": item_data.get("bidCount", 0),
+        "current_bid": {
+            "value": _money_value(current_bid_price) or 0,
+            "currency": current_bid_currency,
+        },
+        "end_time": item_data.get("itemEndDate"),
+        "marketplace_id": item_data.get("listingMarketplaceId"),
+    }
+    return json.dumps(auction_data)
+
+
+def _categories(item_data: dict[str, Any]) -> str | None:
+    categories = item_data.get("categories")
+    if not categories:
+        return None
+    if isinstance(categories, str):
+        return categories
+    return json.dumps(
+        {
+            "ids": [category["categoryId"] for category in categories],
+            "names": [category["categoryName"] for category in categories],
+        }
+    )
+
+
+def _images(item_data: dict[str, Any]) -> str | None:
+    images = item_data.get("images")
+    if images:
+        return _json_text(images)
+
+    image_url = _image_url(item_data)
+    thumbnails = [
+        image.get("imageUrl") for image in item_data.get("thumbnailImages", [])
+    ]
+    if not image_url and not thumbnails:
+        return None
+    return json.dumps({"main": image_url, "thumbnails": thumbnails})
+
+
+def _json_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return json.dumps(value)
+
+
+def _buying_options_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return [option.strip() for option in value.split("|") if option.strip()]
+        return decoded if isinstance(decoded, list) else []
+    return value or []

--- a/app/searches/events.py
+++ b/app/searches/events.py
@@ -1,9 +1,100 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+ITEM_DISCOVERED = "item.discovered"
+ITEM_UPDATED = "item.updated"
+PRICE_DROPPED = "item.price_dropped"
+AUCTION_ENDING_SOON = "item.auction_ending_soon"
+
+
+@dataclass(frozen=True)
+class DomainEvent:
+    """Domain event emitted while processing items for a saved search."""
+
+    event_type: str
+    user_id: Any
+    search_id: Any
+    item_id: Any
+    ebay_id: str | None
+    occurred_at: datetime
+    payload: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
 class SearchProcessingResult:
-    new_items: list = field(default_factory=list)
-    updated_items: list = field(default_factory=list)
-    price_drops: list = field(default_factory=list)
-    ending_auctions: list = field(default_factory=list)
+    new_items: list[Any] = field(default_factory=list)
+    updated_items: list[Any] = field(default_factory=list)
+    price_drops: list[dict[str, Any]] = field(default_factory=list)
+    ending_auctions: list[Any] = field(default_factory=list)
+    domain_events: list[DomainEvent] = field(default_factory=list)
+
+
+def build_item_discovered_event(
+    query: Any, item: Any, occurred_at: datetime
+) -> DomainEvent:
+    """Create an event for an item newly associated with a search."""
+    return _item_event(ITEM_DISCOVERED, query, item, occurred_at)
+
+
+def build_item_updated_event(
+    query: Any,
+    item: Any,
+    occurred_at: datetime,
+    changes: dict[str, dict[str, Any]],
+) -> DomainEvent:
+    """Create an event for changed item attributes."""
+    return _item_event(ITEM_UPDATED, query, item, occurred_at, {"changes": changes})
+
+
+def build_price_dropped_event(
+    query: Any,
+    item: Any,
+    occurred_at: datetime,
+    old_price: float,
+    new_price: float,
+) -> DomainEvent:
+    """Create an event for a lower observed item price."""
+    return _item_event(
+        PRICE_DROPPED,
+        query,
+        item,
+        occurred_at,
+        {"old_price": old_price, "new_price": new_price},
+    )
+
+
+def build_auction_ending_soon_event(
+    query: Any,
+    item: Any,
+    occurred_at: datetime,
+    end_time: datetime,
+) -> DomainEvent:
+    """Create an event for an auction ending inside the alert window."""
+    return _item_event(
+        AUCTION_ENDING_SOON,
+        query,
+        item,
+        occurred_at,
+        {"end_time": end_time},
+    )
+
+
+def _item_event(
+    event_type: str,
+    query: Any,
+    item: Any,
+    occurred_at: datetime,
+    payload: dict[str, Any] | None = None,
+) -> DomainEvent:
+    return DomainEvent(
+        event_type=event_type,
+        user_id=getattr(query, "user_id", None),
+        search_id=getattr(query, "query_id", None),
+        item_id=getattr(item, "item_id", None),
+        ebay_id=getattr(item, "ebay_id", None),
+        occurred_at=occurred_at,
+        payload=payload or {},
+    )

--- a/app/searches/item_processor.py
+++ b/app/searches/item_processor.py
@@ -1,30 +1,88 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable
 
 from app.extensions import db
+from app.items.normalization import normalize_item_payload
 from app.notifications import EventNotificationService
 from app.repositories import ItemRepository
-from app.searches.events import SearchProcessingResult
+from app.searches.events import (
+    DomainEvent,
+    SearchProcessingResult,
+    build_auction_ending_soon_event,
+    build_item_discovered_event,
+    build_item_updated_event,
+    build_price_dropped_event,
+)
+
+ITEM_DIFF_FIELDS = (
+    "title",
+    "price",
+    "current_bid",
+    "current_bid_currency",
+    "currency",
+    "url",
+    "image_url",
+    "seller",
+    "seller_rating",
+    "condition",
+    "location_country",
+    "postal_code",
+    "start_time",
+    "end_time",
+    "buying_options",
+    "auction_details",
+    "categories",
+    "marketplace",
+    "images",
+)
+
+OBSERVATION_HOOKS = (
+    "record_item_observation",
+    "store_item_observation",
+    "write_item_observation",
+    "record_observation",
+)
+
+EVENT_HOOKS = (
+    "record_domain_event",
+    "store_domain_event",
+    "emit_domain_event",
+    "record_event",
+    "store_event",
+    "emit_event",
+)
 
 
 class SearchItemProcessor:
-    def __init__(self, item_repository=None, notification_service=None):
+    def __init__(
+        self,
+        item_repository: Any = None,
+        notification_service: Any = None,
+        event_repository: Any = None,
+        observation_repository: Any = None,
+    ) -> None:
         self.items = item_repository or ItemRepository()
         self.notifications = notification_service or EventNotificationService()
+        self.events = event_repository or self.items
+        self.observations = observation_repository or self.items
 
     def process(
         self,
-        items,
-        query,
-        check_existing=False,
-        full_scan=False,
-        notify=True,
-        first_run=False,
-    ):
+        items: Iterable[dict[str, Any]],
+        query: Any,
+        check_existing: bool = False,
+        full_scan: bool = False,
+        notify: bool = True,
+        first_run: bool = False,
+    ) -> SearchProcessingResult:
         result = SearchProcessingResult()
         current_time = datetime.now(timezone.utc)
         keyword = query.keyword
 
-        for item_data in items:
+        for raw_item_data in items:
+            item_data = normalize_item_payload(raw_item_data)
             item = self._upsert_item_for_query(
                 item_data=item_data,
                 query=query,
@@ -35,6 +93,7 @@ class SearchItemProcessor:
             )
 
             if item is not None:
+                self._record_observation(item, item_data, query, current_time)
                 self._track_ending_auction(item, item_data, query, result, current_time)
 
         try:
@@ -48,55 +107,132 @@ class SearchItemProcessor:
             db.session.rollback()
             raise
 
-    def _upsert_item_for_query(self, item_data, query, keyword, result, current_time, first_run):
+    def _upsert_item_for_query(
+        self,
+        item_data: dict[str, Any],
+        query: Any,
+        keyword: Any,
+        result: SearchProcessingResult,
+        current_time: datetime,
+        first_run: bool,
+    ) -> Any | None:
         print(f"[Process Items] Starting item processing for query {query.query_id}")
-        existing = self.items.get_by_ebay_id(item_data["ebay_id"])
+        ebay_id = item_data.get("ebay_id")
+        if not ebay_id:
+            raise ValueError("Cannot process item payload without ebay_id")
+
+        existing = self.items.get_by_ebay_id(ebay_id)
 
         if existing:
-            feedback = self.items.get_feedback(
-                user_id=query.user_id,
-                item_id=existing.item_id,
-                keyword_id=keyword.keyword_id,
+            return self._process_existing_item(
+                existing,
+                item_data,
+                query,
+                keyword,
+                result,
+                current_time,
+                first_run,
             )
-            self.items.link_keyword(keyword.keyword_id, existing.item_id)
 
-            if feedback and feedback.is_relevant is False:
-                return None
+        return self._process_new_item(
+            item_data, query, keyword, result, current_time, first_run
+        )
 
-            link = self.items.link_query(
-                query.query_id,
-                existing.item_id,
-                created_at=current_time,
+    def _process_existing_item(
+        self,
+        item: Any,
+        item_data: dict[str, Any],
+        query: Any,
+        keyword: Any,
+        result: SearchProcessingResult,
+        current_time: datetime,
+        first_run: bool,
+    ) -> Any | None:
+        feedback = self.items.get_feedback(
+            user_id=query.user_id,
+            item_id=item.item_id,
+            keyword_id=keyword.keyword_id,
+        )
+        self.items.link_keyword(keyword.keyword_id, item.item_id)
+
+        if feedback and feedback.is_relevant is False:
+            return None
+
+        link = self.items.link_query(
+            query.query_id, item.item_id, created_at=current_time
+        )
+        if link and not first_run:
+            self._record_new_item(item, query, result, current_time)
+
+        old_price = getattr(item, "price", None)
+        item_changes = _diff_item(item, item_data)
+        if self.items.update_item(item, item_data, current_time):
+            result.updated_items.append(item)
+            self._record_event(
+                build_item_updated_event(query, item, current_time, item_changes),
+                result,
             )
-            if link and not first_run:
-                result.new_items.append(existing)
 
-            old_price = existing.price
-            if self.items.update_item(existing, item_data, current_time):
-                result.updated_items.append(existing)
+        price_drop_values = _price_drop_values(old_price, item_data.get("price"))
+        if price_drop_values:
+            old_price_value, new_price_value = price_drop_values
+            price_drop = {
+                "item": item,
+                "old_price": old_price_value,
+                "new_price": new_price_value,
+            }
+            result.price_drops.append(price_drop)
+            self._record_event(
+                build_price_dropped_event(
+                    query,
+                    item,
+                    current_time,
+                    old_price_value,
+                    new_price_value,
+                ),
+                result,
+            )
 
-            new_price = item_data.get("price")
-            if new_price and old_price and new_price < old_price:
-                result.price_drops.append(
-                    {
-                        "item": existing,
-                        "old_price": old_price,
-                        "new_price": new_price,
-                    }
-                )
+        return item
 
-            return existing
-
-        new_item = self.items.create_item(item_data)
-        self.items.link_keyword(keyword.keyword_id, new_item.item_id, found_at=current_time)
-        self.items.link_query(query.query_id, new_item.item_id, created_at=current_time)
+    def _process_new_item(
+        self,
+        item_data: dict[str, Any],
+        query: Any,
+        keyword: Any,
+        result: SearchProcessingResult,
+        current_time: datetime,
+        first_run: bool,
+    ) -> Any:
+        item = self.items.create_item(item_data)
+        self.items.link_keyword(keyword.keyword_id, item.item_id, found_at=current_time)
+        self.items.link_query(query.query_id, item.item_id, created_at=current_time)
 
         if not first_run:
-            result.new_items.append(new_item)
+            self._record_new_item(item, query, result, current_time)
 
-        return new_item
+        return item
 
-    def _track_ending_auction(self, item, item_data, query, result, current_time):
+    def _record_new_item(
+        self,
+        item: Any,
+        query: Any,
+        result: SearchProcessingResult,
+        current_time: datetime,
+    ) -> None:
+        result.new_items.append(item)
+        self._record_event(
+            build_item_discovered_event(query, item, current_time), result
+        )
+
+    def _track_ending_auction(
+        self,
+        item: Any,
+        item_data: dict[str, Any],
+        query: Any,
+        result: SearchProcessingResult,
+        current_time: datetime,
+    ) -> None:
         end_time = item_data.get("end_time")
         if not end_time:
             return
@@ -111,9 +247,75 @@ class SearchItemProcessor:
         if user_query_item and not user_query_item.auction_ending_notification_sent:
             result.ending_auctions.append(item)
             user_query_item.auction_ending_notification_sent = True
+            self._record_event(
+                build_auction_ending_soon_event(query, item, current_time, end_time),
+                result,
+            )
+
+    def _record_observation(
+        self,
+        item: Any,
+        item_data: dict[str, Any],
+        query: Any,
+        observed_at: datetime,
+    ) -> None:
+        observation = {
+            "user_id": getattr(query, "user_id", None),
+            "search_id": getattr(query, "query_id", None),
+            "item_id": getattr(item, "item_id", None),
+            "ebay_id": item_data.get("ebay_id"),
+            "observed_at": observed_at,
+            "price": item_data.get("price"),
+            "currency": item_data.get("currency"),
+            "payload": item_data,
+        }
+        _call_optional_repository_hook(
+            self.observations, OBSERVATION_HOOKS, observation
+        )
+
+    def _record_event(self, event: DomainEvent, result: SearchProcessingResult) -> None:
+        result.domain_events.append(event)
+        _call_optional_repository_hook(self.events, EVENT_HOOKS, event)
 
 
-def process_items(items, query, check_existing=False, full_scan=False, notify=True, first_run=False):
+def _diff_item(item: Any, item_data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    changes = {}
+    for field in ITEM_DIFF_FIELDS:
+        if field not in item_data or not hasattr(item, field):
+            continue
+        old_value = getattr(item, field)
+        new_value = item_data[field]
+        if old_value != new_value:
+            changes[field] = {"old": old_value, "new": new_value}
+    return changes
+
+
+def _price_drop_values(old_price: Any, new_price: Any) -> tuple[float, float] | None:
+    if old_price is None or new_price is None or new_price >= old_price:
+        return None
+    return float(old_price), float(new_price)
+
+
+def _call_optional_repository_hook(
+    repository: Any,
+    hook_names: tuple[str, ...],
+    payload: Any,
+) -> Any | None:
+    for hook_name in hook_names:
+        hook = getattr(repository, hook_name, None)
+        if callable(hook):
+            return hook(payload)
+    return None
+
+
+def process_items(
+    items: Iterable[dict[str, Any]],
+    query: Any,
+    check_existing: bool = False,
+    full_scan: bool = False,
+    notify: bool = True,
+    first_run: bool = False,
+) -> tuple[list[Any], list[Any]]:
     result = SearchItemProcessor().process(
         items=items,
         query=query,

--- a/app/searches/item_processor.py
+++ b/app/searches/item_processor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterable
 
@@ -55,6 +56,13 @@ EVENT_HOOKS = (
 )
 
 
+@dataclass(frozen=True)
+class ItemProcessingOutcome:
+    item: Any
+    is_new_item: bool
+    hard_filter_passed: bool = True
+
+
 class SearchItemProcessor:
     def __init__(
         self,
@@ -83,7 +91,7 @@ class SearchItemProcessor:
 
         for raw_item_data in items:
             item_data = normalize_item_payload(raw_item_data)
-            item = self._upsert_item_for_query(
+            outcome = self._upsert_item_for_query(
                 item_data=item_data,
                 query=query,
                 keyword=keyword,
@@ -92,9 +100,11 @@ class SearchItemProcessor:
                 first_run=first_run,
             )
 
-            if item is not None:
-                self._record_observation(item, item_data, query, current_time)
-                self._track_ending_auction(item, item_data, query, result, current_time)
+            if outcome is not None:
+                self._record_observation(outcome, item_data, query, current_time)
+                self._track_ending_auction(
+                    outcome.item, item_data, query, result, current_time
+                )
 
         try:
             db.session.commit()
@@ -115,7 +125,7 @@ class SearchItemProcessor:
         result: SearchProcessingResult,
         current_time: datetime,
         first_run: bool,
-    ) -> Any | None:
+    ) -> ItemProcessingOutcome | None:
         print(f"[Process Items] Starting item processing for query {query.query_id}")
         ebay_id = item_data.get("ebay_id")
         if not ebay_id:
@@ -147,7 +157,7 @@ class SearchItemProcessor:
         result: SearchProcessingResult,
         current_time: datetime,
         first_run: bool,
-    ) -> Any | None:
+    ) -> ItemProcessingOutcome | None:
         feedback = self.items.get_feedback(
             user_id=query.user_id,
             item_id=item.item_id,
@@ -161,7 +171,8 @@ class SearchItemProcessor:
         link = self.items.link_query(
             query.query_id, item.item_id, created_at=current_time
         )
-        if link and not first_run:
+        is_new_item = link is not None
+        if is_new_item and not first_run:
             self._record_new_item(item, query, result, current_time)
 
         old_price = getattr(item, "price", None)
@@ -193,7 +204,7 @@ class SearchItemProcessor:
                 result,
             )
 
-        return item
+        return ItemProcessingOutcome(item=item, is_new_item=is_new_item)
 
     def _process_new_item(
         self,
@@ -203,7 +214,7 @@ class SearchItemProcessor:
         result: SearchProcessingResult,
         current_time: datetime,
         first_run: bool,
-    ) -> Any:
+    ) -> ItemProcessingOutcome:
         item = self.items.create_item(item_data)
         self.items.link_keyword(keyword.keyword_id, item.item_id, found_at=current_time)
         self.items.link_query(query.query_id, item.item_id, created_at=current_time)
@@ -211,7 +222,7 @@ class SearchItemProcessor:
         if not first_run:
             self._record_new_item(item, query, result, current_time)
 
-        return item
+        return ItemProcessingOutcome(item=item, is_new_item=True)
 
     def _record_new_item(
         self,
@@ -254,28 +265,22 @@ class SearchItemProcessor:
 
     def _record_observation(
         self,
-        item: Any,
+        outcome: ItemProcessingOutcome,
         item_data: dict[str, Any],
         query: Any,
         observed_at: datetime,
     ) -> None:
-        observation = {
-            "user_id": getattr(query, "user_id", None),
-            "search_id": getattr(query, "query_id", None),
-            "item_id": getattr(item, "item_id", None),
-            "ebay_id": item_data.get("ebay_id"),
-            "observed_at": observed_at,
-            "price": item_data.get("price"),
-            "currency": item_data.get("currency"),
-            "payload": item_data,
-        }
-        _call_optional_repository_hook(
-            self.observations, OBSERVATION_HOOKS, observation
+        _persist_observation(
+            self.observations,
+            outcome,
+            item_data,
+            query,
+            observed_at,
         )
 
     def _record_event(self, event: DomainEvent, result: SearchProcessingResult) -> None:
         result.domain_events.append(event)
-        _call_optional_repository_hook(self.events, EVENT_HOOKS, event)
+        _persist_domain_event(self.events, event)
 
 
 def _diff_item(item: Any, item_data: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -294,6 +299,80 @@ def _price_drop_values(old_price: Any, new_price: Any) -> tuple[float, float] | 
     if old_price is None or new_price is None or new_price >= old_price:
         return None
     return float(old_price), float(new_price)
+
+
+def _persist_domain_event(repository: Any, event: DomainEvent) -> Any | None:
+    create = getattr(repository, "create", None)
+    if callable(create):
+        return create(
+            event_type=event.event_type,
+            aggregate_type="item",
+            aggregate_id=event.item_id or event.ebay_id,
+            user_id=event.user_id,
+            query_id=event.search_id,
+            item_id=event.item_id,
+            payload=_serialize_for_persistence(event.payload),
+            status="pending",
+            source="search_item_processor",
+            occurred_at=event.occurred_at,
+        )
+    return _call_optional_repository_hook(repository, EVENT_HOOKS, event)
+
+
+def _persist_observation(
+    repository: Any,
+    outcome: ItemProcessingOutcome,
+    item_data: dict[str, Any],
+    query: Any,
+    observed_at: datetime,
+) -> Any | None:
+    observation = _observation_payload(outcome, item_data, query, observed_at)
+    create = getattr(repository, "create", None)
+    if callable(create):
+        return create(**observation)
+    return _call_optional_repository_hook(repository, OBSERVATION_HOOKS, observation)
+
+
+def _observation_payload(
+    outcome: ItemProcessingOutcome,
+    item_data: dict[str, Any],
+    query: Any,
+    observed_at: datetime,
+) -> dict[str, Any]:
+    return {
+        "item_id": getattr(outcome.item, "item_id", None),
+        "query_id": getattr(query, "query_id", None),
+        "search_run_id": _search_run_id(query, item_data),
+        "observed_at": observed_at,
+        "price": item_data.get("price"),
+        "currency": item_data.get("currency"),
+        "current_bid": item_data.get("current_bid"),
+        "condition": item_data.get("condition"),
+        "buying_options": item_data.get("buying_options"),
+        "raw_item_snapshot": _serialize_for_persistence(item_data),
+        "is_new_item": outcome.is_new_item,
+        "hard_filter_passed": outcome.hard_filter_passed,
+    }
+
+
+def _search_run_id(query: Any, item_data: dict[str, Any]) -> Any:
+    return (
+        item_data.get("search_run_id")
+        or getattr(query, "search_run_id", None)
+        or getattr(query, "current_search_run_id", None)
+    )
+
+
+def _serialize_for_persistence(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {key: _serialize_for_persistence(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_serialize_for_persistence(item) for item in value]
+    if isinstance(value, tuple):
+        return [_serialize_for_persistence(item) for item in value]
+    return value
 
 
 def _call_optional_repository_hook(

--- a/app/tests/test_item_processing_events.py
+++ b/app/tests/test_item_processing_events.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+
+from app.searches import item_processor
+from app.searches.events import (
+    AUCTION_ENDING_SOON,
+    ITEM_DISCOVERED,
+    ITEM_UPDATED,
+    PRICE_DROPPED,
+    SearchProcessingResult,
+)
+from app.searches.item_processor import SearchItemProcessor, process_items
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.committed = False
+        self.rolled_back = False
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+
+
+class FakeRepository:
+    def __init__(self) -> None:
+        self.items_by_ebay_id: dict[str, Any] = {}
+        self.query_links: dict[tuple[Any, Any], Any] = {}
+        self.created_payloads: list[dict[str, Any]] = []
+        self.observations: list[dict[str, Any]] = []
+        self.events: list[Any] = []
+        self.next_item_id = 1
+
+    def get_by_ebay_id(self, ebay_id: str) -> Any | None:
+        return self.items_by_ebay_id.get(ebay_id)
+
+    def get_feedback(self, user_id: Any, item_id: Any, keyword_id: Any) -> None:
+        return None
+
+    def create_item(self, item_data: dict[str, Any]) -> Any:
+        item = SimpleNamespace(item_id=self.next_item_id, **item_data)
+        self.next_item_id += 1
+        self.items_by_ebay_id[item.ebay_id] = item
+        self.created_payloads.append(item_data)
+        return item
+
+    def link_keyword(self, keyword_id: Any, item_id: Any, found_at: Any = None) -> Any:
+        return SimpleNamespace(
+            keyword_id=keyword_id, item_id=item_id, found_at=found_at
+        )
+
+    def link_query(
+        self, query_id: Any, item_id: Any, created_at: Any = None
+    ) -> Any | None:
+        key = (query_id, item_id)
+        if key in self.query_links:
+            return None
+        link = SimpleNamespace(
+            query_id=query_id,
+            item_id=item_id,
+            created_at=created_at,
+            auction_ending_notification_sent=False,
+        )
+        self.query_links[key] = link
+        return link
+
+    def get_query_item(self, query_id: Any, item_id: Any) -> Any | None:
+        return self.query_links.get((query_id, item_id))
+
+    def update_item(
+        self, item: Any, item_data: dict[str, Any], updated_at: datetime
+    ) -> bool:
+        changed = False
+        for key, value in item_data.items():
+            if key == "item_id" or not hasattr(item, key):
+                continue
+            if getattr(item, key) != value:
+                setattr(item, key, value)
+                changed = True
+        if changed:
+            item.last_updated = updated_at
+        return changed
+
+    def record_item_observation(self, observation: dict[str, Any]) -> None:
+        self.observations.append(observation)
+
+    def record_domain_event(self, event: Any) -> None:
+        self.events.append(event)
+
+
+class FakeNotifications:
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+
+    def notify_search_events(self, query: Any, result: SearchProcessingResult) -> None:
+        self.calls.append((query, result))
+
+
+def test_processor_normalizes_raw_sdk_payload_and_records_new_item_event(
+    monkeypatch: Any,
+) -> None:
+    session = FakeSession()
+    monkeypatch.setattr(item_processor.db, "session", session)
+    repository = FakeRepository()
+    query = _query()
+
+    raw_item = {
+        "itemId": "v1|123",
+        "legacyItemId": "123",
+        "title": "Pokemon card",
+        "price": {"value": "129.95", "currency": "GBP"},
+        "itemWebUrl": "https://example.test/item",
+        "image": {"imageUrl": "https://example.test/image.jpg"},
+        "seller": {"username": "seller-one", "feedbackPercentage": "99.8"},
+        "itemLocation": {"country": "GB", "postalCode": "SW1A"},
+        "buyingOptions": ["FIXED_PRICE"],
+        "listingMarketplaceId": "EBAY_GB",
+    }
+
+    result = SearchItemProcessor(
+        item_repository=repository,
+        notification_service=FakeNotifications(),
+    ).process([raw_item], query, notify=False)
+
+    created_payload = repository.created_payloads[0]
+    assert created_payload["ebay_id"] == "v1|123"
+    assert created_payload["price"] == 129.95
+    assert created_payload["location"] == {"country": "GB", "postal_code": "SW1A"}
+    assert created_payload["location_country"] == "GB"
+    assert result.new_items == [repository.items_by_ebay_id["v1|123"]]
+    assert [event.event_type for event in result.domain_events] == [ITEM_DISCOVERED]
+    assert repository.events == result.domain_events
+    assert repository.observations[0]["price"] == 129.95
+    assert session.committed is True
+
+
+def test_processor_records_update_and_price_drop_events(monkeypatch: Any) -> None:
+    monkeypatch.setattr(item_processor.db, "session", FakeSession())
+    repository = FakeRepository()
+    query = _query()
+    existing = SimpleNamespace(
+        item_id=42,
+        ebay_id="abc",
+        title="Old title",
+        price=100.0,
+        currency="GBP",
+        last_updated=None,
+    )
+    repository.items_by_ebay_id["abc"] = existing
+    repository.query_links[(query.query_id, existing.item_id)] = SimpleNamespace(
+        auction_ending_notification_sent=False
+    )
+
+    result = SearchItemProcessor(
+        item_repository=repository,
+        notification_service=FakeNotifications(),
+    ).process(
+        [{"ebay_id": "abc", "title": "New title", "price": 75.0}], query, notify=False
+    )
+
+    assert result.updated_items == [existing]
+    assert result.price_drops == [
+        {"item": existing, "old_price": 100.0, "new_price": 75.0}
+    ]
+    assert [event.event_type for event in result.domain_events] == [
+        ITEM_UPDATED,
+        PRICE_DROPPED,
+    ]
+    assert result.domain_events[0].payload["changes"]["title"] == {
+        "old": "Old title",
+        "new": "New title",
+    }
+    assert repository.observations[0]["item_id"] == existing.item_id
+
+
+def test_processor_records_auction_ending_event(monkeypatch: Any) -> None:
+    monkeypatch.setattr(item_processor.db, "session", FakeSession())
+    repository = FakeRepository()
+    query = _query()
+    existing = SimpleNamespace(item_id=7, ebay_id="auction-1", price=50.0)
+    repository.items_by_ebay_id["auction-1"] = existing
+    link = SimpleNamespace(auction_ending_notification_sent=False)
+    repository.query_links[(query.query_id, existing.item_id)] = link
+
+    end_time = datetime.now(timezone.utc) + timedelta(hours=2)
+    result = SearchItemProcessor(
+        item_repository=repository,
+        notification_service=FakeNotifications(),
+    ).process(
+        [
+            {
+                "ebay_id": "auction-1",
+                "title": "Auction",
+                "price": 50.0,
+                "end_time": end_time,
+            }
+        ],
+        query,
+        notify=False,
+    )
+
+    assert result.ending_auctions == [existing]
+    assert link.auction_ending_notification_sent is True
+    assert [event.event_type for event in result.domain_events] == [AUCTION_ENDING_SOON]
+    assert result.domain_events[0].payload["end_time"] == end_time
+
+
+def test_legacy_process_items_return_shape_is_preserved(monkeypatch: Any) -> None:
+    class StubProcessor:
+        def process(self, **kwargs: Any) -> SearchProcessingResult:
+            return SearchProcessingResult(new_items=["new"], updated_items=["updated"])
+
+    monkeypatch.setattr(item_processor, "SearchItemProcessor", StubProcessor)
+
+    assert process_items([], _query()) == (["new"], ["updated"])
+
+
+def _query() -> Any:
+    return SimpleNamespace(
+        query_id="search-1",
+        user_id=100,
+        keyword=SimpleNamespace(keyword_id=200, keyword_text="pokemon"),
+    )

--- a/app/tests/test_item_processing_events.py
+++ b/app/tests/test_item_processing_events.py
@@ -101,6 +101,15 @@ class FakeNotifications:
         self.calls.append((query, result))
 
 
+class FakeCreateRepository:
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> dict[str, Any]:
+        self.created.append(kwargs)
+        return kwargs
+
+
 def test_processor_normalizes_raw_sdk_payload_and_records_new_item_event(
     monkeypatch: Any,
 ) -> None:
@@ -137,6 +146,94 @@ def test_processor_normalizes_raw_sdk_payload_and_records_new_item_event(
     assert repository.events == result.domain_events
     assert repository.observations[0]["price"] == 129.95
     assert session.committed is True
+
+
+def test_processor_persists_domain_events_with_schema_fields(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(item_processor.db, "session", FakeSession())
+    item_repository = FakeRepository()
+    event_repository = FakeCreateRepository()
+    query = _query()
+    end_time = datetime.now(timezone.utc) + timedelta(hours=1)
+    existing = SimpleNamespace(item_id=42, ebay_id="abc", price=100.0)
+    item_repository.items_by_ebay_id["abc"] = existing
+    item_repository.query_links[(query.query_id, existing.item_id)] = SimpleNamespace(
+        auction_ending_notification_sent=False
+    )
+
+    result = SearchItemProcessor(
+        item_repository=item_repository,
+        event_repository=event_repository,
+        notification_service=FakeNotifications(),
+    ).process(
+        [{"ebay_id": "abc", "price": 75.0, "end_time": end_time}],
+        query,
+        notify=False,
+    )
+
+    assert [event.event_type for event in result.domain_events] == [
+        ITEM_UPDATED,
+        PRICE_DROPPED,
+        AUCTION_ENDING_SOON,
+    ]
+    price_drop = event_repository.created[1]
+    assert price_drop == {
+        "event_type": PRICE_DROPPED,
+        "aggregate_type": "item",
+        "aggregate_id": existing.item_id,
+        "user_id": query.user_id,
+        "query_id": query.query_id,
+        "item_id": existing.item_id,
+        "payload": {"old_price": 100.0, "new_price": 75.0},
+        "status": "pending",
+        "source": "search_item_processor",
+        "occurred_at": result.domain_events[1].occurred_at,
+    }
+    assert event_repository.created[2]["payload"] == {"end_time": end_time.isoformat()}
+
+
+def test_processor_persists_observations_with_schema_fields(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(item_processor.db, "session", FakeSession())
+    item_repository = FakeRepository()
+    observation_repository = FakeCreateRepository()
+    query = _query(search_run_id="run-1")
+    end_time = datetime.now(timezone.utc) + timedelta(days=1)
+
+    SearchItemProcessor(
+        item_repository=item_repository,
+        observation_repository=observation_repository,
+        notification_service=FakeNotifications(),
+    ).process(
+        [
+            {
+                "ebay_id": "abc",
+                "price": 50.0,
+                "currency": "GBP",
+                "current_bid": 25.0,
+                "condition": "USED",
+                "buying_options": '["AUCTION"]',
+                "end_time": end_time,
+            }
+        ],
+        query,
+        notify=False,
+    )
+
+    observation = observation_repository.created[0]
+    assert observation["item_id"] == item_repository.items_by_ebay_id["abc"].item_id
+    assert observation["query_id"] == query.query_id
+    assert observation["search_run_id"] == "run-1"
+    assert observation["price"] == 50.0
+    assert observation["currency"] == "GBP"
+    assert observation["current_bid"] == 25.0
+    assert observation["condition"] == "USED"
+    assert observation["buying_options"] == '["AUCTION"]'
+    assert observation["raw_item_snapshot"]["end_time"] == end_time.isoformat()
+    assert observation["is_new_item"] is True
+    assert observation["hard_filter_passed"] is True
 
 
 def test_processor_records_update_and_price_drop_events(monkeypatch: Any) -> None:
@@ -220,9 +317,12 @@ def test_legacy_process_items_return_shape_is_preserved(monkeypatch: Any) -> Non
     assert process_items([], _query()) == (["new"], ["updated"])
 
 
-def _query() -> Any:
-    return SimpleNamespace(
+def _query(search_run_id: str | None = None) -> Any:
+    query = SimpleNamespace(
         query_id="search-1",
         user_id=100,
         keyword=SimpleNamespace(keyword_id=200, keyword_text="pokemon"),
     )
+    if search_run_id is not None:
+        query.search_run_id = search_run_id
+    return query


### PR DESCRIPTION
## Summary
- Refactors search item processing into smaller normalization, upsert, diffing, event, observation, and auction-alert helpers.
- Adds storage-ready eBay SDK payload normalization in `app/items/normalization.py` without editing `ebay_client/**`.
- Extends `SearchProcessingResult` with optional domain events while preserving the legacy `process_items(...) -> (new_items, updated_items)` return shape.
- Adds optional repository hooks for item observations and domain events; current repositories without those hooks keep existing behavior.

## Linked Task
Refs CS-19. No matching GitHub issue was found to auto-close.

## Preserved Behavior
- Existing callable names and imports remain available.
- Notification result lists for new items, updated items, price drops, and ending auctions are preserved.
- `first_run` still suppresses new-item notification entries.
- Negative relevance feedback still skips item notification/update handling.

## New Behavior
- Raw or parsed SDK item payloads are normalized before storage.
- Existing items are diffed before update and emit `item.updated` events when changed.
- New search associations emit `item.discovered` events, price drops emit `item.price_dropped`, and auction alerts emit `item.auction_ending_soon`.
- Observation/event persistence is attempted through compatible repository methods when present.

## Migrations
None.

## Tests and Checks
- `python3 -m compileall app ebay_client config.py` passed.
- `/tmp/coco-search-cs19-venv/bin/python -m pytest app/tests/test_item_processing_events.py -q` passed: 4 tests.
- `/tmp/coco-search-cs19-venv/bin/black .` was run as requested; formatter-only changes outside this worker's ownership, including `ebay_client/**`, were restored. Scoped black check passed for changed files.
- `/tmp/coco-search-cs19-venv/bin/python -m pytest` currently fails during collection on existing project issues: missing legacy `Query`/`LongTermItem`, missing `cancel_subscription_logic`, missing `pandas`, and missing `ENCRYPTION_KEY`.
- `/tmp/coco-search-cs19-venv/bin/mypy .` currently fails on existing repo-wide type/stub issues outside this change.

## Risks / Open Questions
- Domain event and observation storage are compatibility hooks only until concrete repository/schema methods are added.
- Event payloads include Python datetime objects; future durable event storage may need serialization policy at the repository boundary.
