### PR TITLE
[codex] Keep scheduled jobs as thin wrappers

### DIFF
--- a/app/_scheduler/sync.py
+++ b/app/_scheduler/sync.py
@@ -1,0 +1,81 @@
+from collections.abc import Callable, Iterable
+from typing import Protocol
+
+from app._scheduler.job_manager import add_query_jobs, remove_query_jobs
+from app.extensions import scheduler
+from app.models import UserQuery
+
+QUERY_JOB_PREFIX = "query_"
+
+
+class SchedulerLike(Protocol):
+    def get_jobs(self):
+        """Return scheduled jobs."""
+
+
+class ScheduledJobSynchronizer:
+    """Reconcile active saved searches with APScheduler query jobs."""
+
+    def __init__(
+        self,
+        active_query_ids: Callable[[], Iterable[str]] | None = None,
+        scheduler_client: SchedulerLike | None = None,
+        add_jobs: Callable[[str], None] = add_query_jobs,
+        remove_jobs: Callable[[str], None] = remove_query_jobs,
+    ) -> None:
+        self.active_query_ids = active_query_ids or list_active_saved_search_ids
+        self.scheduler = scheduler_client or scheduler
+        self.add_jobs = add_jobs
+        self.remove_jobs = remove_jobs
+
+    def sync(self) -> None:
+        active_query_ids = set(self.active_query_ids())
+        scheduled_query_ids = self._scheduled_query_ids()
+
+        print(f"SYNC_JOBS: Active queries: {len(active_query_ids)}")
+        print(f"SYNC_JOBS: Scheduled queries: {len(scheduled_query_ids)}")
+
+        self._add_missing_jobs(active_query_ids, scheduled_query_ids)
+        self._remove_stale_jobs(active_query_ids, scheduled_query_ids)
+
+    def _scheduled_query_ids(self) -> set[str]:
+        scheduled_ids = set()
+        for job in self.scheduler.get_jobs():
+            query_id = query_id_from_job_id(job.id)
+            if query_id:
+                scheduled_ids.add(query_id)
+        return scheduled_ids
+
+    def _add_missing_jobs(
+        self, active_query_ids: set[str], scheduled_query_ids: set[str]
+    ) -> None:
+        for query_id in active_query_ids - scheduled_query_ids:
+            print(f"SYNC_JOBS: Adding job for query {query_id}")
+            self.add_jobs(query_id)
+
+    def _remove_stale_jobs(
+        self, active_query_ids: set[str], scheduled_query_ids: set[str]
+    ) -> None:
+        for query_id in scheduled_query_ids - active_query_ids:
+            print(f"SYNC_JOBS: Removing job for query {query_id}")
+            self.remove_jobs(query_id)
+
+
+def query_id_from_job_id(job_id: str) -> str | None:
+    if not job_id.startswith(QUERY_JOB_PREFIX):
+        return None
+
+    parts = job_id.split("_")
+    if len(parts) < 3:
+        return None
+
+    return "_".join(parts[1:-1])
+
+
+def list_active_saved_search_ids() -> list[str]:
+    rows = (
+        UserQuery.query.with_entities(UserQuery.query_id)
+        .filter_by(is_active=True)
+        .all()
+    )
+    return [str(query_id) for (query_id,) in rows]

--- a/app/jobs/query_check.py
+++ b/app/jobs/query_check.py
@@ -1,28 +1,18 @@
-from app.extensions import db, scheduler
+from app.jobs.runtime import run_with_scheduler_context
 from app.searches.item_processor import process_items
 from app.searches.scheduled import ScheduledQueryService
 
 
 def full_scrape_job(query_id):
-    with scheduler.app.app_context():
-        try:
-            ScheduledQueryService().run_full_scrape(query_id)
-        except Exception as e:
-            db.session.rollback()
-            print(f"Error: {e}")
-        finally:
-            db.session.remove()
+    return run_with_scheduler_context(
+        lambda: ScheduledQueryService().run_full_scrape(query_id)
+    )
 
 
 def recent_scrape_job(query_id):
-    with scheduler.app.app_context():
-        try:
-            ScheduledQueryService().run_recent_scrape(query_id)
-        except Exception as e:
-            db.session.rollback()
-            print(f"Error: {e}")
-        finally:
-            db.session.remove()
+    return run_with_scheduler_context(
+        lambda: ScheduledQueryService().run_recent_scrape(query_id)
+    )
 
 
 __all__ = ["full_scrape_job", "recent_scrape_job", "process_items"]

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -1,0 +1,19 @@
+from collections.abc import Callable
+from typing import TypeVar
+
+from app.extensions import db, scheduler
+
+T = TypeVar("T")
+
+
+def run_with_scheduler_context(work: Callable[[], T]) -> T | None:
+    """Run scheduled work inside the Flask app context with session cleanup."""
+    with scheduler.app.app_context():
+        try:
+            return work()
+        except Exception as exc:
+            db.session.rollback()
+            print(f"Error: {exc}")
+            return None
+        finally:
+            db.session.remove()

--- a/app/jobs/snyc_jobs.py
+++ b/app/jobs/snyc_jobs.py
@@ -1,6 +1,6 @@
+from app._scheduler.sync import ScheduledJobSynchronizer
 from app.extensions import scheduler
-from app.models import UserQuery
-from app._scheduler.job_manager import add_query_jobs, remove_query_jobs
+
 
 @scheduler.task(
     "interval",
@@ -10,25 +10,4 @@ from app._scheduler.job_manager import add_query_jobs, remove_query_jobs
 )
 def sync_jobs():
     with scheduler.app.app_context():
-        # Get active query UUIDs
-        active = {str(q.query_id) for q in UserQuery.query.filter_by(is_active=True).all()}
-        print(f"SYNC_JOBS: Active queries: {len(active)}")
-        # Get scheduled UUIDs from job IDs
-        scheduled = set()
-        for job in scheduler.get_jobs():
-            if job.id.startswith('query_'):
-                parts = job.id.split('_')
-                if len(parts) >= 3:
-                    uuid_str = '_'.join(parts[1:-1])  # Handle UUIDs with underscores
-                    scheduled.add(uuid_str)
-        print(f"SYNC_JOBS: Scheduled queries: {len(scheduled)}")
-        
-        # Add missing jobs
-        for qid in active - scheduled:
-            print(f"SYNC_JOBS: Adding job for query {qid}")
-            add_query_jobs(qid)
-            
-        # Remove deleted jobs
-        for qid in scheduled - active:
-            print(f"SYNC_JOBS: Removing job for query {qid}")
-            remove_query_jobs(qid)
+        ScheduledJobSynchronizer().sync()

--- a/app/searches/scheduled.py
+++ b/app/searches/scheduled.py
@@ -5,20 +5,68 @@ from app.repositories import UserQueryRepository
 from app.searches.execution import scrape_ebay, scrape_new_items
 from app.searches.item_processor import process_items
 
+FULL_SCRAPE_INTERVAL = timedelta(hours=24)
+
 
 class ScheduledQueryService:
-    def __init__(self, query_repository=None):
+    def __init__(
+        self,
+        query_repository=None,
+        full_search=None,
+        recent_search=None,
+        item_processor=None,
+        run_recorder=None,
+        session=None,
+        clock=None,
+    ):
         self.queries = query_repository or UserQueryRepository()
+        self.full_search = full_search or scrape_ebay
+        self.recent_search = recent_search or scrape_new_items
+        self.item_processor = item_processor or process_items
+        self.run_recorder = run_recorder
+        self.session = session or db.session
+        self.clock = clock or (lambda: datetime.now(timezone.utc))
 
     def run_full_scrape(self, query_id):
         print(f"FULL_SCRAPE_JOB: Query ID: {query_id}")
+        self._run_scheduled_search(
+            query_id=query_id,
+            run_type="full",
+            search=self.full_search,
+            process=self._process_full_scrape,
+            finish=self._finish_full_scrape,
+        )
+
+    def run_recent_scrape(self, query_id):
+        print(f"RECENT_SCRAPE_JOB: Query ID: {query_id}")
+        self._run_scheduled_search(
+            query_id=query_id,
+            run_type="recent",
+            search=self.recent_search,
+            process=self._process_recent_scrape,
+            finish=self._finish_recent_scrape,
+        )
+
+    def _run_scheduled_search(self, query_id, run_type, search, process, finish):
         query = self.queries.get_active(query_id)
         if not query:
             scheduler.app.logger.debug("[Job %s] Aborting - no active query", query_id)
             return
 
+        run = self._start_run(query, run_type)
+        try:
+            items = self._execute_search(query, search)
+            process(items, query)
+            finish(query)
+            self._finish_run_success(run, len(items))
+            self.session.commit()
+        except Exception as exc:
+            self._finish_run_failure(run, exc)
+            raise
+
+    def _execute_search(self, query, search):
         keyword = self.queries.get_keyword(query.keyword_id)
-        items = scrape_ebay(
+        return search(
             keyword.keyword_text,
             filters=_filters_for_query(query),
             required_keywords=query.required_keywords,
@@ -26,36 +74,41 @@ class ScheduledQueryService:
             marketplace=query.marketplace,
         )
 
-        process_items(
+    def _process_full_scrape(self, items, query):
+        self.item_processor(
             items,
             query,
             full_scan=True,
             notify=True,
             first_run=query.first_run,
         )
+
+    def _process_recent_scrape(self, items, query):
+        self.item_processor(items, query, check_existing=False, notify=True)
+
+    def _finish_full_scrape(self, query):
+        now = self.clock()
         query.first_run = False
-        query.last_full_run = datetime.now(timezone.utc)
-        query.next_full_run = datetime.now(timezone.utc) + timedelta(hours=24)
-        db.session.commit()
+        query.last_full_run = now
+        query.next_full_run = now + FULL_SCRAPE_INTERVAL
 
-    def run_recent_scrape(self, query_id):
-        print(f"RECENT_SCRAPE_JOB: Query ID: {query_id}")
-        query = self.queries.get_active(query_id)
-        if not query:
-            print(f"[Job {query_id}] Aborting - no active query")
-            return
+    def _finish_recent_scrape(self, query):
+        query.last_recent_run = self.clock()
 
-        keyword = self.queries.get_keyword(query.keyword_id)
-        items = scrape_new_items(
-            keyword.keyword_text,
-            filters=_filters_for_query(query),
-            required_keywords=query.required_keywords,
-            excluded_keywords=query.excluded_keywords,
-            marketplace=query.marketplace,
-        )
-        process_items(items, query, check_existing=False, notify=True)
-        query.last_recent_run = datetime.now(timezone.utc)
-        db.session.commit()
+    def _start_run(self, query, run_type):
+        if not self.run_recorder:
+            return None
+        return self.run_recorder.start(query=query, run_type=run_type)
+
+    def _finish_run_success(self, run, item_count):
+        if run is not None:
+            self.run_recorder.finish_success(run, item_count=item_count)
+
+    def _finish_run_failure(self, run, exc):
+        if run is not None:
+            self.session.rollback()
+            self.run_recorder.finish_failure(run, error=str(exc))
+            self.session.commit()
 
 
 def _filters_for_query(query):

--- a/app/tests/test_scheduled_jobs.py
+++ b/app/tests/test_scheduled_jobs.py
@@ -1,0 +1,154 @@
+from types import SimpleNamespace
+from datetime import datetime, timezone
+
+import pytest
+
+from app._scheduler.sync import ScheduledJobSynchronizer, query_id_from_job_id
+from app.jobs import query_check
+from app.searches.scheduled import ScheduledQueryService
+
+
+def test_query_check_keeps_public_scheduled_callables():
+    assert callable(query_check.full_scrape_job)
+    assert callable(query_check.recent_scrape_job)
+    assert callable(query_check.process_items)
+
+
+def test_query_id_from_job_id_extracts_query_id():
+    assert query_id_from_job_id("query_abc-123_full") == "abc-123"
+    assert query_id_from_job_id("query_part_one_recent") == "part_one"
+
+
+def test_query_id_from_job_id_ignores_non_query_jobs():
+    assert query_id_from_job_id("sync_jobs") is None
+    assert query_id_from_job_id("query_") is None
+
+
+def test_scheduled_job_synchronizer_adds_missing_and_removes_stale_jobs():
+    added = []
+    removed = []
+    scheduler = SimpleNamespace(
+        get_jobs=lambda: [
+            SimpleNamespace(id="query_active-b_recent"),
+            SimpleNamespace(id="query_stale-c_full"),
+            SimpleNamespace(id="sync_jobs"),
+        ]
+    )
+
+    ScheduledJobSynchronizer(
+        active_query_ids=lambda: ["active-a", "active-b"],
+        scheduler_client=scheduler,
+        add_jobs=added.append,
+        remove_jobs=removed.append,
+    ).sync()
+
+    assert added == ["active-a"]
+    assert removed == ["stale-c"]
+
+
+def test_scheduled_query_service_runs_full_scrape_and_records_success():
+    query = _query()
+    session = _session()
+    recorder = _run_recorder()
+    processed = []
+    now = datetime(2026, 4, 28, tzinfo=timezone.utc)
+
+    ScheduledQueryService(
+        query_repository=_query_repository(query),
+        full_search=lambda *args, **kwargs: [{"ebay_id": "item-1"}],
+        item_processor=lambda *args, **kwargs: processed.append((args, kwargs)),
+        run_recorder=recorder,
+        session=session,
+        clock=lambda: now,
+    ).run_full_scrape("query-1")
+
+    assert processed
+    assert query.first_run is False
+    assert query.last_full_run == now
+    assert recorder.started == [("query-1", "full")]
+    assert recorder.succeeded == [("run-full", 1)]
+    assert session.commits == 1
+
+
+def test_scheduled_query_service_records_failed_run_before_reraising():
+    query = _query()
+    session = _session()
+    recorder = _run_recorder()
+
+    service = ScheduledQueryService(
+        query_repository=_query_repository(query),
+        full_search=_failing_search,
+        run_recorder=recorder,
+        session=session,
+    )
+
+    with pytest.raises(RuntimeError):
+        service.run_full_scrape("query-1")
+
+    assert recorder.failed == [("run-full", "search failed")]
+    assert session.rollbacks == 1
+    assert session.commits == 1
+
+
+def _query():
+    return SimpleNamespace(
+        query_id="query-1",
+        keyword_id="keyword-1",
+        min_price=None,
+        max_price=None,
+        item_location="GB",
+        condition=None,
+        buying_options=None,
+        required_keywords=None,
+        excluded_keywords=None,
+        marketplace="EBAY_GB",
+        first_run=True,
+        last_full_run=None,
+        next_full_run=None,
+        last_recent_run=None,
+    )
+
+
+def _query_repository(query):
+    return SimpleNamespace(
+        get_active=lambda query_id: query if query_id == query.query_id else None,
+        get_keyword=lambda keyword_id: SimpleNamespace(keyword_text="camera"),
+    )
+
+
+def _session():
+    class Session:
+        def __init__(self):
+            self.commits = 0
+            self.rollbacks = 0
+
+        def commit(self):
+            self.commits += 1
+
+        def rollback(self):
+            self.rollbacks += 1
+
+    return Session()
+
+
+def _run_recorder():
+    recorder = SimpleNamespace(started=[], succeeded=[], failed=[])
+
+    def start(query, run_type):
+        recorder.started.append((query.query_id, run_type))
+        return f"run-{run_type}"
+
+    def finish_success(run, item_count):
+        recorder.succeeded.append((run, item_count))
+
+    def finish_failure(run, error):
+        recorder.failed.append((run, error))
+
+    recorder.start = start
+    recorder.finish_success = finish_success
+    recorder.finish_failure = finish_failure
+    return recorder
+
+
+def _failing_search(*args, **kwargs):
+    raise RuntimeError("search failed")


### PR DESCRIPTION
## Summary
- Keep `full_scrape_job`, `recent_scrape_job`, and `process_items` callable from `app.jobs.query_check` while moving shared scheduler app-context/session cleanup into a small runtime helper.
- Refactor scheduled search execution into a lower-complexity orchestration path with injectable search, processing, session, clock, and optional run-recorder hooks for success/failure tracking when a run repository exists.
- Move sync-job reconciliation out of the APScheduler wrapper into `app/_scheduler/sync.py`, without changing `ebay_client/**` or `app/repositories/queries.py`.

## Validation
- `venv/bin/python -m compileall app/searches/scheduled.py app/jobs/runtime.py app/_scheduler/sync.py app/jobs/query_check.py app/jobs/snyc_jobs.py app/tests/test_scheduled_jobs.py`
- `venv/bin/pytest app/tests/test_scheduled_jobs.py` (6 passed)

## Risk Notes
- No persistent search-run model/repository exists in this branch, so run success/failure recording is implemented as an optional `run_recorder` integration point and is a no-op unless injected.
- Full-suite `pytest` still fails during collection on existing unrelated test drift: missing `Query`, `archive_items`, `cancel_subscription_logic`, and missing `ENCRYPTION_KEY` for the telegram notification test.
- `mypy .` still reports existing project-wide typing/stub issues, including third-party stubs and unrelated `ebay_client` type errors; no `ebay_client/**` files were edited.