### PR TITLE
[codex] Align notification records with repository schema

### DIFF
--- a/app/notifications/records.py
+++ b/app/notifications/records.py
@@ -8,43 +8,69 @@ from app.notifications.events import NotificationEvent, item_from_payload
 class NotificationRecordCreator:
     """Persist notification records through an injected repository."""
 
-    def __init__(self, repository: Any | None = None) -> None:
+    def __init__(
+        self, repository: Any | None = None, channel: str = "telegram"
+    ) -> None:
         self.repository = repository
+        self.channel = channel
 
     def create_records(
         self,
         user: Any,
         event: NotificationEvent,
         payloads: list[Any],
-    ) -> int:
+    ) -> list[Any]:
         """Create records when a repository is available."""
-        if self.repository is None:
-            return 0
+        repository = self.repository
+        if repository is None or not hasattr(repository, "create"):
+            return []
 
-        created = 0
+        records = []
         for payload in payloads:
-            if self._create_record(user, event, payload):
-                created += 1
-        return created
+            record = self._create_record(repository, user, event, payload)
+            if record is not None:
+                records.append(record)
+        return records
 
-    def _create_record(self, user: Any, event: NotificationEvent, payload: Any) -> bool:
+    def mark_sent(self, records: list[Any]) -> None:
+        """Mark created notification records as sent when supported."""
+        self._mark_records("mark_sent", records)
+
+    def mark_failed(self, records: list[Any]) -> None:
+        """Mark created notification records as failed when supported."""
+        self._mark_records("mark_failed", records)
+
+    def _create_record(
+        self,
+        repository: Any,
+        user: Any,
+        event: NotificationEvent,
+        payload: Any,
+    ) -> Any:
         item = item_from_payload(payload)
-        item_id = getattr(item, "item_id", getattr(item, "id", None))
-        metadata = self._metadata(payload)
-        data = {
-            "user_id": getattr(user, "id", event.user_id),
-            "search_id": event.search_id,
-            "item_id": item_id,
-            "notification_type": event.notification_type,
-            "metadata": metadata,
-        }
+        return repository.create(
+            query_id=event.search_id,
+            payload={
+                "user_id": getattr(user, "id", event.user_id),
+                "notification_type": event.notification_type,
+                "query_text": event.query_text,
+                "item_id": getattr(item, "item_id", getattr(item, "id", None)),
+                "metadata": self._metadata(payload),
+            },
+            channel=self.channel,
+            status="pending",
+        )
 
-        for method_name in ("create_notification", "create", "add"):
-            method = getattr(self.repository, method_name, None)
-            if method is not None:
-                method(**data)
-                return True
-        return False
+    def _mark_records(self, method_name: str, records: list[Any]) -> None:
+        if self.repository is None or not records:
+            return
+
+        method = getattr(self.repository, method_name, None)
+        if method is None:
+            return
+
+        for record in records:
+            method(record)
 
     def _metadata(self, payload: Any) -> dict[str, Any]:
         if isinstance(payload, dict):

--- a/app/notifications/service.py
+++ b/app/notifications/service.py
@@ -56,8 +56,12 @@ class EventNotificationService:
                 continue
 
             rendered = self.renderer.render(event, payloads)
-            self.records.create_records(user, event, payloads)
-            self.sender.send(user, rendered)
+            records = self.records.create_records(user, event, payloads)
+            sent = self.sender.send(user, rendered)
+            if sent:
+                self.records.mark_sent(records)
+            else:
+                self.records.mark_failed(records)
             counts[event.notification_type] += len(payloads)
 
         return counts

--- a/app/tests/test_notification_service.py
+++ b/app/tests/test_notification_service.py
@@ -35,18 +35,28 @@ class RelevanceServiceStub:
 class NotificationRepositoryStub:
     def __init__(self) -> None:
         self.records: list[dict[str, Any]] = []
+        self.sent: list[dict[str, Any]] = []
+        self.failed: list[dict[str, Any]] = []
 
-    def create_notification(self, **kwargs: Any) -> None:
+    def create(self, **kwargs: Any) -> dict[str, Any]:
         self.records.append(kwargs)
+        return kwargs
+
+    def mark_sent(self, record: dict[str, Any]) -> None:
+        self.sent.append(record)
+
+    def mark_failed(self, record: dict[str, Any]) -> None:
+        self.failed.append(record)
 
 
 class SenderStub(NotificationSender):
-    def __init__(self) -> None:
+    def __init__(self, sent: bool = True) -> None:
+        self.delivery_result = sent
         self.sent: list[tuple[Any, RenderedNotification]] = []
 
     def send(self, user: Any, notification: RenderedNotification) -> bool:
         self.sent.append((user, notification))
-        return True
+        return self.delivery_result
 
 
 def test_notify_search_events_filters_by_relevance_and_records_notifications() -> None:
@@ -77,13 +87,20 @@ def test_notify_search_events_filters_by_relevance_and_records_notifications() -
     assert sender.sent[0][1].payloads == [first_item]
     assert records.records == [
         {
-            "user_id": user.id,
-            "search_id": query.query_id,
-            "item_id": first_item.item_id,
-            "notification_type": "new_items",
-            "metadata": {},
+            "query_id": query.query_id,
+            "payload": {
+                "user_id": user.id,
+                "notification_type": "new_items",
+                "query_text": "sony camera",
+                "item_id": first_item.item_id,
+                "metadata": {},
+            },
+            "channel": "telegram",
+            "status": "pending",
         }
     ]
+    assert records.sent == records.records
+    assert records.failed == []
 
 
 def test_notify_search_events_respects_disabled_preferences() -> None:
@@ -136,6 +153,28 @@ def test_notify_search_events_preserves_legacy_event_buckets() -> None:
     ]
     assert sender.sent[1][1].payloads == result.price_drops
     assert sender.sent[2][1].payloads == result.ending_auctions
+
+
+def test_notify_search_events_marks_records_failed_when_delivery_fails() -> None:
+    user = _user(preferences={"new_items": True})
+    query = _query(user_id=user.id)
+    item = ItemStub(item_id=1, title="undelivered item")
+    result = SimpleNamespace(
+        new_items=[item],
+        price_drops=[],
+        ending_auctions=[],
+    )
+    records = NotificationRepositoryStub()
+
+    counts = EventNotificationService(
+        user_repository=UserRepositoryStub(user),
+        notification_repository=records,
+        sender=SenderStub(sent=False),
+    ).notify_search_events(query, result)
+
+    assert counts == {"new_items": 1, "price_drops": 0, "auction_alerts": 0}
+    assert records.sent == []
+    assert records.failed == records.records
 
 
 def _user(preferences: dict[str, bool]) -> Any:


### PR DESCRIPTION
## Summary
- Aligns `NotificationRecordCreator` with the notification repository schema by calling `repository.create(query_id=..., payload=..., channel=..., status="pending")`.
- Tracks delivery status through `mark_sent(record)` and `mark_failed(record)` when those repository methods are available.
- Updates notification service flow to mark records after sender delivery result.
- Extends notification service tests to cover schema-aligned create payloads and failed-delivery marking.

Closes #21

## Context
PR #65 was already merged before this follow-up could be marked ready, so this PR contains only the requested notification-record alignment delta on top of latest `origin/develop`.

## Validation
- Passed: `/tmp/coco-search-cs21-py311/bin/python -m pytest app/tests/test_notification_service.py`
- Passed: `python3 -m compileall app ebay_client config.py`
- Passed: `/tmp/coco-search-cs21-py311/bin/black --check app/notifications app/tests/test_notification_service.py`
- Blocked: `/tmp/coco-search-cs21-py311/bin/python -m pytest` fails during collection on existing out-of-scope test drift: missing `Query` model imports, missing `archive_items` / `load_historical_items`, missing `cancel_subscription_logic`, and missing local `ENCRYPTION_KEY`.
- Blocked: `/tmp/coco-search-cs21-py311/bin/mypy .` reports existing repo-wide missing stubs/model drift and current out-of-scope type errors. No notification-module errors remain from this patch.
- Not run as modifying command: `black .` would reformat 50 out-of-scope files, including `ebay_client/**`; scoped files were formatted instead.

## Notes
- No migrations added.
- `ebay_client/**`, models, repositories, relevance, searches, routes, and jobs were not edited.
